### PR TITLE
SDL: Always re-render the entire text screen for now as a workaround

### DIFF
--- a/src/gui/sdl.cpp
+++ b/src/gui/sdl.cpp
@@ -269,7 +269,7 @@ void bx_sdl_gui_c::text_update(u8* old_text, u8* new_text,
 	u32           text_palette[16];
 
 	//  UNUSED(nrows);
-	forceUpdate = 0;
+	forceUpdate = 1;
 	if (charmap_updated)
 	{
 		forceUpdate = 1;


### PR DESCRIPTION
The old comparison method appears to be messed up, so it's disabled as a workaround. The entire screen in text modes is now always re-rendered instead.