### PR TITLE
Fix a number of "xxx overrides a member function but is not marked 'o…

### DIFF
--- a/src/S3Trio64.h
+++ b/src/S3Trio64.h
@@ -94,15 +94,15 @@
 class CS3Trio64 : public CVGA, public CRunnable, public mame_machine_provider
 {
 public:
-  virtual int   SaveState(FILE* f);
-  virtual int   RestoreState(FILE* f);
-  virtual void  check_state();
-  virtual void  WriteMem_Legacy(int index, u32 address, int dsize, u32 data);
-  virtual u32   ReadMem_Legacy(int index, u32 address, int dsize);
+  virtual int   SaveState(FILE* f) override;
+  virtual int   RestoreState(FILE* f) override;
+  virtual void  check_state() override;
+  virtual void  WriteMem_Legacy(int index, u32 address, int dsize, u32 data) override;
+  virtual u32   ReadMem_Legacy(int index, u32 address, int dsize) override;
 
   virtual void  WriteMem_Bar(int func, int bar, u32 address, int dsize,
-    u32 data);
-  virtual u32   ReadMem_Bar(int func, int bar, u32 address, int dsize);
+    u32 data) override;
+  virtual u32   ReadMem_Bar(int func, int bar, u32 address, int dsize) override;
 
   virtual u64 ReadMem(int index, u64 address, int dsize) override;
   virtual void WriteMem(int index, u64 address, int dsize, u64 data) override;
@@ -129,15 +129,15 @@ public:
   virtual       ~CS3Trio64();
 
   void          update(void);
-  virtual void  run(void);
+  virtual void  run(void) override;
 
-  virtual u8    get_actl_palette_idx(u8 index);
+  virtual u8    get_actl_palette_idx(u8 index) override;
   virtual void  redraw_area(unsigned x0, unsigned y0, unsigned width,
-    unsigned height);
+    unsigned height) override;
 
-  virtual void  init();
-  virtual void  start_threads();
-  virtual void  stop_threads();
+  virtual void  init() override;
+  virtual void  start_threads() override;
+  virtual void  stop_threads() override;
 protected:
   virtual u16      line_compare_mask() override;
 
@@ -229,12 +229,12 @@ protected:
     uint8_t sr1a;
     uint8_t sr1b;
   } s3;
-  virtual uint16_t offset();
+  virtual uint16_t offset() override;
 
-  virtual uint32_t latch_start_addr(); // below is MAME's base VGA implementation, but S3 Trio in MAME overrides it with the version we have
-  virtual bool get_interlace_mode() { return BIT(s3.cr42, 5); }
+  virtual uint32_t latch_start_addr() override; // below is MAME's base VGA implementation, but S3 Trio in MAME overrides it with the version we have
+  virtual bool get_interlace_mode() override { return BIT(s3.cr42, 5); }
 
-  virtual void palette_update();
+  virtual void palette_update() override;
   virtual void s3_define_video_mode(void);
 
   nop_callback m_vsync_cb;

--- a/src/gui/sdl.cpp
+++ b/src/gui/sdl.cpp
@@ -105,19 +105,19 @@ class bx_sdl_gui_c : public bx_gui_c
 {
 public:
 	bx_sdl_gui_c(CConfigurator* cfg);
-	virtual void    specific_init(unsigned x_tilesize, unsigned y_tilesize);
-	virtual void    text_update(u8* old_text, u8* new_text, unsigned long cursor_x, unsigned long cursor_y, bx_vga_tminfo_t tm_info, unsigned rows) {};
-	virtual void    graphics_tile_update(u8* snapshot, unsigned x, unsigned y);
-	virtual void    handle_events(void);
-	virtual void    flush(void);
-	virtual void    clear_screen(void);
-	virtual bool    palette_change(unsigned index, unsigned red, unsigned green, unsigned blue);
-	virtual void    dimension_update(unsigned x, unsigned y, unsigned fheight = 0, unsigned fwidth = 0, unsigned bpp = 8);
-	virtual void    mouse_enabled_changed_specific(bool val);
-	virtual void    exit(void);
-	virtual			bx_svga_tileinfo_t* graphics_tile_info(bx_svga_tileinfo_t* info);
-	virtual			u8* graphics_tile_get(unsigned x, unsigned y, unsigned* w, unsigned* h);
-	virtual void    graphics_tile_update_in_place(unsigned x, unsigned y, unsigned w, unsigned h);
+	virtual void    specific_init(unsigned x_tilesize, unsigned y_tilesize) override;
+	virtual void    text_update(u8* old_text, u8* new_text, unsigned long cursor_x, unsigned long cursor_y, bx_vga_tminfo_t tm_info, unsigned rows) override {}
+	virtual void    graphics_tile_update(u8* snapshot, unsigned x, unsigned y) override;
+	virtual void    handle_events(void) override;
+	virtual void    flush(void) override;
+	virtual void    clear_screen(void) override;
+	virtual bool    palette_change(unsigned index, unsigned red, unsigned green, unsigned blue) override;
+	virtual void    dimension_update(unsigned x, unsigned y, unsigned fheight = 0, unsigned fwidth = 0, unsigned bpp = 8) override;
+	virtual void    mouse_enabled_changed_specific(bool val) override;
+	virtual void    exit(void) override;
+	virtual			bx_svga_tileinfo_t* graphics_tile_info(bx_svga_tileinfo_t* info) override;
+	virtual			u8* graphics_tile_get(unsigned x, unsigned y, unsigned* w, unsigned* h) override;
+	virtual void    graphics_tile_update_in_place(unsigned x, unsigned y, unsigned w, unsigned h) override;
 	void			graphics_frame_update(const u32* pixels, unsigned w, unsigned h) override;
 private:
 	CConfigurator* myCfg;


### PR DESCRIPTION
…verride'" warnings (clang)