### PR TITLE
AliM1543C_ide: Remove duplicate case, fixes the build

### DIFF
--- a/src/AliM1543C_ide.cpp
+++ b/src/AliM1543C_ide.cpp
@@ -2598,7 +2598,6 @@ void CAliM1543C_ide::execute(int index)
 		case 0xe6:    // sleep
 		case 0xe7:    // flush cache
 		case 0xea:    // flush cache ext
-		case 0xe5:    //no idea  NT SP5 spams this like crazy 
 			SEL_STATUS(index).busy = false;
 			SEL_STATUS(index).drive_ready = true;
 			SEL_STATUS(index).drq = false;


### PR DESCRIPTION
Case was added in 19b355932c3951847cfd7a2899bf69458e11ca17 and then again in bced8c996ad5bf83dd63db667ed8592735af19b3.

Fixes this problem:
```
AliM1543C_ide.cpp:2601:17: error: duplicate case value
 2601 |                 case 0xe5:    //no idea  NT SP5 spams this like crazy
      |                 ^~~~
AliM1543C_ide.cpp:2597:17: note: previously used here
 2597 |                 case 0xe5:    // check power mode
      |                 ^~~~
make: *** [Makefile:1025: AliM1543C_ide.o] Error 1
```