### PR TITLE
Clean up unnecessary files in Windows artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -392,7 +392,10 @@ jobs:
           Remove-Item -Recurse -Force $artifactDir -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Force -Path $artifactDir | Out-Null
 
-          Copy-Item -Recurse -Force (Join-Path $configDir "*") $artifactDir
+          
+          Get-ChildItem -Path $configDir -File |
+            Where-Object { $_.Extension -in '.exe', '.dll', '.pdb' } |
+            Copy-Item -Destination $artifactDir -Force
 
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Update artifact copying logic for Windows in build.yml, the zip file size is now one-sixth of the original.