### PR TITLE
Set proper resolution in text mode

### DIFF
--- a/src/S3Trio64.cpp
+++ b/src/S3Trio64.cpp
@@ -4522,7 +4522,7 @@ void CS3Trio64::determine_screen_dimensions(unsigned* piHeight,
 	for (i = 0; i < 0x20; i++)
 		ai[i] = m_crtc_map.read_byte(i);
 
-	h = (ai[1] + 1) * 8;
+	h = (ai[1] + 1) * (seq_dotperchar() ? 8 : 9);
 	v = (ai[18] | ((ai[7] & 0x02) << 7) | ((ai[7] & 0x40) << 3)) + 1;
 	// S3 CR5E extends V* with bit10 (0x400)
 	if (m_crtc_map.read_byte(0x5E) & 0x02) v |= 0x400;

--- a/src/S3Trio64.h
+++ b/src/S3Trio64.h
@@ -372,12 +372,13 @@ private:
   void lfb_recalc_and_cache();  // recompute enable/base/size from COMMAND+BAR0 (and CR regs if you wish)
   void trace_lfb_if_changed(const char* reason);
 
-  inline bool seq_chain_four() const { return (vga.sequencer.data[4] & 0x08) != 0; }
-  inline bool seq_odd_even()   const { return (vga.sequencer.data[4] & 0x04) != 0; }
-  inline bool seq_extended_mem()const { return (vga.sequencer.data[4] & 0x02) != 0; }
-  inline bool seq_reset1()     const { return (vga.sequencer.data[0] & 0x01) != 0; }
-  inline bool seq_reset2()     const { return (vga.sequencer.data[0] & 0x02) != 0; }
-  inline bool x_dotclockdiv2() const { return (vga.sequencer.data[1] & 0x08) != 0; }
+  inline bool seq_chain_four()   const { return (vga.sequencer.data[4] & 0x08) != 0; }
+  inline bool seq_odd_even()     const { return (vga.sequencer.data[4] & 0x04) != 0; }
+  inline bool seq_extended_mem() const { return (vga.sequencer.data[4] & 0x02) != 0; }
+  inline bool seq_reset1()       const { return (vga.sequencer.data[0] & 0x01) != 0; }
+  inline bool seq_reset2()       const { return (vga.sequencer.data[0] & 0x02) != 0; }
+  inline bool seq_dotperchar()   const { return (vga.sequencer.data[1] & 0x01) != 0; }
+  inline bool x_dotclockdiv2()   const { return (vga.sequencer.data[1] & 0x08) != 0; }
 
   // cached state for LFB
   u32  lfb_base_ = 0;


### PR DESCRIPTION
Text mode should use 9 dots per character, fix firmware update CD display and Windows NT setup in text mode.