### PR TITLE
Make PCI Unused Space return -1 instead of 0 to make the ARC memory self-test happy.

### DIFF
--- a/src/S3Trio64.cpp
+++ b/src/S3Trio64.cpp
@@ -3895,7 +3895,7 @@ u32 CS3Trio64::legacy_read(u32 address, int dsize)
 		}
 	}
 
-	u32 data = 0;
+	u32 data = 0xffffffff;
 	switch (dsize)
 	{
 	case 32:

--- a/src/System.cpp
+++ b/src/System.cpp
@@ -1221,7 +1221,7 @@ u64 CSystem::ReadMem(u64 address, int dsize, CSystemComponent* source)
 						a & U64(0xffffffff));
 			}
 
-			return 0;
+			return (dsize >= 64) ? U64(0xffffffffffffffff) : (U64(1) << dsize) - 1;
 		}
 
 		if (a >= U64(0x80200000000) && a < U64(0x80300000000))
@@ -1236,7 +1236,8 @@ u64 CSystem::ReadMem(u64 address, int dsize, CSystemComponent* source)
 			else
 				printf("Read from unknown memory %" PRIx64 " on PCI 1   \n",
 					a & U64(0xffffffff));
-			return 0;
+			
+			return (dsize >= 64) ? U64(0xffffffffffffffff) : (U64(1) << dsize) - 1;
 		}
 
 #if defined(DEBUG_UNKMEM)

--- a/src/VGA.cpp
+++ b/src/VGA.cpp
@@ -1096,7 +1096,7 @@ uint8_t CVGA::mem_r(offs_t offset)
 	{
 		uint8_t i, data;
 
-		data = 0;
+		data = 0xff;
 		//printf("%08x\n",offset);
 
 		for (i = 0; i < 4; i++)


### PR DESCRIPTION
Make PCI Unused Space return -1 instead of 0 to make the AlphaBIOS memory self-test happy.
Even after modification, the memory self-test still reports an error at c0000, which seems to be related to VGABIOS according to its contents.
<img width="642" height="512" alt="image" src="https://github.com/user-attachments/assets/4d0c4489-47a2-43fc-a103-f4896c072035" />
