### PR TITLE
Fix segfault when destroying network interface with bad configuration

### DIFF
--- a/src/DEC21143.cpp
+++ b/src/DEC21143.cpp
@@ -490,7 +490,9 @@ CDEC21143::~CDEC21143()
 {
 	stop_threads();
 
-	pcap_close(fp);
+	if (fp != nullptr) {
+		pcap_close(fp);
+	}
 	delete rx_queue;
 	/* Free TX scratch on device teardown (not on ResetNIC, which expects it alive). */
 	if (state.tx.cur_buf) {


### PR DESCRIPTION
If something goes wrong while initializating the network adapter, the PCAP pointer may be uninitialized, and calling the destructor on the network card can trigger a segfault when it cleans up the PCAP structure. Check that `fp` is null before calling `pcap_close`.