### PR TITLE
Add ES1370 emulation using SDL3 audio backend

### DIFF
--- a/src/AlphaCPU.cpp
+++ b/src/AlphaCPU.cpp
@@ -726,7 +726,7 @@ void CAlphaCPU::execute()
 	UFP ufp1;
 	UFP ufp2;
 
-	bool pbc;
+	bool pbc = false;
 
 	int opcode;
 	int function;

--- a/src/Configurator.cpp
+++ b/src/Configurator.cpp
@@ -926,11 +926,12 @@ void CConfigurator::initialize()
 //		myDevice = new CCirrus(this, (CSystem*)pParent->get_device(), pcibus,
 //			pcidev);
 //		break;
-
+#if defined(HAVE_SDL)
 	case c_es1370:
 		myDevice = new CES1370(this, (CSystem*)pParent->get_device(), pcibus,
 			pcidev);
 		break;
+#endif
 
 #if defined(HAVE_PCAP)
 

--- a/src/Configurator.cpp
+++ b/src/Configurator.cpp
@@ -149,6 +149,7 @@
 #endif
 #include "Sym53C895.h"
 #include "Sym53C810.h"
+#include "ES1370.h"
 #include "MPU401.h"
 
   /**
@@ -711,6 +712,7 @@ classinfo classes[] = {
   {"win32", c_sdl, N_P | IS_GUI},
   {"X11", c_x11, N_P | IS_GUI},
   {"mpu401", c_mpu401, ON_CS },
+  {"es1370", c_es1370, IS_PCI},
   {0, c_none, 0}
 };
 
@@ -924,6 +926,11 @@ void CConfigurator::initialize()
 //		myDevice = new CCirrus(this, (CSystem*)pParent->get_device(), pcibus,
 //			pcidev);
 //		break;
+
+	case c_es1370:
+		myDevice = new CES1370(this, (CSystem*)pParent->get_device(), pcibus,
+			pcidev);
+		break;
 
 #if defined(HAVE_PCAP)
 

--- a/src/Configurator.h
+++ b/src/Configurator.h
@@ -110,6 +110,7 @@ typedef enum
   c_sym53c895,
   c_sym53c810,
   c_mpu401,
+  c_es1370,
 
   // disk devices
   c_file,

--- a/src/ES1370.cpp
+++ b/src/ES1370.cpp
@@ -27,6 +27,14 @@
 
 #include <algorithm>
 
+#ifndef MAX
+#define MAX(a,b)            (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef MIN
+#define MIN(a,b)            (((a) < (b)) ? (a) : (b))
+#endif
+
 /* Missing stuff:
    SCTRL_P[12](END|ST)INC
    SCTRL_P1SCTRLD
@@ -504,14 +512,14 @@ void CES1370::es1370_transfer_audio(ES1370State* s, struct chan* d, int loop_sel
     int transferred = 0;
     int index = d - &s->chan[0];
 
-    to_transfer = min(maxb, min(left, csc_bytes));
+    to_transfer = MIN(maxb, MIN(left, csc_bytes));
     addr += (cnt << 2) + d->leftover;
 
     if (index == ADC_CHANNEL) {
         while (to_transfer > 0) {
             int acquired, to_copy;
 
-            to_copy = min(to_transfer, sizeof(tmpbuf));
+            to_copy = MIN(to_transfer, sizeof(tmpbuf));
             //acquired = audio_be_read(s->audio_be, s->adc_voice, tmpbuf, to_copy);
 			acquired = SDL_GetAudioStreamData(s->adc_voice, tmpbuf, to_copy);
             if (!acquired || acquired == -1) {
@@ -530,7 +538,7 @@ void CES1370::es1370_transfer_audio(ES1370State* s, struct chan* d, int loop_sel
         while (to_transfer > 0) {
             int copied, to_copy;
 
-            to_copy = min(to_transfer, sizeof(tmpbuf));
+            to_copy = MIN(to_transfer, sizeof(tmpbuf));
             //pci_dma_read(&s->dev, addr, tmpbuf, to_copy);
 			do_pci_read(addr, tmpbuf, 1, to_copy);
             copied = SDL_PutAudioStreamData(voice, tmpbuf, to_copy) ? to_copy : 0;

--- a/src/ES1370.cpp
+++ b/src/ES1370.cpp
@@ -22,6 +22,7 @@
  * THE SOFTWARE.
  */
 // Straight port to es40 by Cacodemon345.
+#ifdef HAVE_SDL
 #include "ES1370.h"
 
 #include <algorithm>
@@ -630,3 +631,4 @@ void CES1370::es1370_dac_callback_adc(void* userdata, SDL_AudioStream* stream, i
     ES1370State* s = &dev->s;
     dev->es1370_run_channel(s, 2, additional_amount);
 }
+#endif HAVE_SDL

--- a/src/ES1370.cpp
+++ b/src/ES1370.cpp
@@ -1,0 +1,632 @@
+/*
+ * QEMU ES1370 emulation
+ *
+ * Copyright (c) 2005 Vassili Karpov (malc)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+// Straight port to es40 by Cacodemon345.
+#include "ES1370.h"
+
+#include <algorithm>
+
+/* Missing stuff:
+   SCTRL_P[12](END|ST)INC
+   SCTRL_P1SCTRLD
+   SCTRL_P2DACSEN
+   CTRL_DAC_SYNC
+   MIDI
+   non looped mode
+   surely more
+*/
+
+/**
+ * PCI Configuration Data Block
+ **/
+u32 es_cfg_data[64] =
+{
+    /*00*/  0x50001274,         // CFID: vendor + device
+    /*04*/  0x02000001,         // CFCS: command + status
+    /*08*/  0x04010000,         // CFRV: class + revision
+    /*0c*/  0x00000000,         // CFLT: latency timer + cache line size
+    /*10*/  0x00000001,         // BAR0: IO Space
+    /*14*/  0x00000000,         // BAR1:
+    /*18*/  0x00000000,         // BAR2:
+    /*1c*/  0x00000000,         // BAR3:
+    /*20*/  0x00000000,         // BAR4:
+    /*24*/  0x00000000,         // BAR5:
+    /*28*/  0x00000000,         // CCIC: CardBus
+    /*2c*/  0x4c4c4942,         // CSID: subsystem + vendor
+    /*30*/  0x00000000,         // BAR6: expansion rom base
+    /*34*/  0x00000000,         // CCAP: capabilities pointer
+    /*38*/  0x00000000,
+    /*3c*/  0x401101ff,         // CFIT: interrupt configuration
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+/**
+ * PCI Configuration Mask Block
+ **/
+u32 es_cfg_mask[64] = {
+    /*00*/ 0x00000000,  // CFID: vendor + device
+    /*04*/ 0x00000157,  // CFCS: command + status
+    /*08*/ 0x00000000,  // CFRV: class + revision
+    /*0c*/ 0x0000ffff,  // CFLT: latency timer + cache line size
+    /*10*/ 0xffffff00,  // BAR0: IO space (256 bytes)
+    /*14*/ 0x00000000,  // BAR1:
+    /*18*/ 0x00000000,  // BAR2:
+    /*1c*/ 0x00000000,  // BAR3:
+    /*20*/ 0x00000000,  // BAR4:
+    /*24*/ 0x00000000,  // BAR5:
+    /*28*/ 0x00000000,  // CCIC: CardBus
+    /*2c*/ 0x00000000,  // CSID: subsystem + vendor
+    /*30*/ 0x00000000,  // BAR6: expansion rom base
+    /*34*/ 0x00000000,  // CCAP: capabilities pointer
+    /*38*/ 0x00000000,
+    /*3c*/ 0x000000ff,  // CFIT: interrupt configuration
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+CES1370::CES1370(CConfigurator* cfg, class CSystem* c, int pcibus, int pcidev) : CPCIDevice(cfg, c, pcibus, pcidev)
+{
+    SDL_AudioSpec as;
+
+    as.freq = 44100;
+    as.channels = 2;
+    as.format = SDL_AUDIO_S16LE;
+	memset((void*)&s, 0, sizeof(s));
+    if (!SDL_Init(SDL_INIT_AUDIO)) {
+		FAILURE_1(SDL, "Failed to initialize SDL audio: %s", SDL_GetError());
+    }
+	s.audio_be_in = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_RECORDING, nullptr);
+    if (!s.audio_be_in) {
+        FAILURE_1(SDL, "Failed to initialize SDL audio input: %s", SDL_GetError());
+    }
+    s.audio_be_out = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, nullptr);
+    if (!s.audio_be_out) {
+        FAILURE_1(SDL, "Failed to initialize SDL audio output: %s", SDL_GetError());
+    }
+    s.adc_voice = SDL_CreateAudioStream(NULL, &as);
+	s.dac_voice[0] = SDL_CreateAudioStream(&as, NULL);
+    s.dac_voice[1] = SDL_CreateAudioStream(&as, NULL);
+
+	SDL_SetAudioStreamPutCallback(s.adc_voice, es1370_dac_callback_adc, this);
+    SDL_SetAudioStreamGetCallback(s.dac_voice[0], es1370_dac_callback_dac1, this);
+    SDL_SetAudioStreamGetCallback(s.dac_voice[1], es1370_dac_callback_dac2, this);
+}
+
+CES1370::~CES1370()
+{
+    SDL_DestroyAudioStream(s.adc_voice);
+    SDL_DestroyAudioStream(s.dac_voice[0]);
+    SDL_DestroyAudioStream(s.dac_voice[1]);
+    SDL_CloseAudioDevice(s.audio_be_in);
+    SDL_CloseAudioDevice(s.audio_be_out);
+}
+
+void CES1370::init()
+{
+    add_function(0, es_cfg_data, es_cfg_mask);
+    ResetPCI();
+    es1370_reset(&s);
+    es1370_update_voices(&s, s.ctl, s.sctl);
+}
+
+void CES1370::es1370_update_status(ES1370State* s, uint32_t new_status)
+{
+	uint32_t level = new_status & (STAT_DAC1 | STAT_DAC2 | STAT_ADC);
+
+	if (level) {
+		s->status = new_status | STAT_INTR;
+	}
+	else {
+		s->status = new_status & ~STAT_INTR;
+	}
+	do_pci_interrupt(0, !!level);
+}
+
+void CES1370::es1370_reset(ES1370State* s)
+{
+	size_t i;
+
+	s->ctl = 1;
+	s->status = 0x60;
+	s->mempage = 0;
+	s->codec = 0;
+	s->sctl = 0;
+
+	for (i = 0; i < NB_CHANNELS; ++i) {
+		struct chan* d = &s->chan[i];
+		d->scount = 0;
+		d->leftover = 0;
+		if (i == ADC_CHANNEL) {
+			SDL_UnbindAudioStream(s->adc_voice);
+		}
+		else {
+			SDL_UnbindAudioStream(s->dac_voice[i]);
+		}
+	}
+	do_pci_interrupt(0, 0);
+    es1370_update_voices(s, s->ctl, s->sctl);
+}
+
+void CES1370::es1370_maybe_lower_irq(ES1370State* s, uint32_t sctl)
+{
+	uint32_t new_status = s->status;
+
+	if (!(sctl & SCTRL_P1INTEN) && (s->sctl & SCTRL_P1INTEN)) {
+		new_status &= ~STAT_DAC1;
+	}
+
+	if (!(sctl & SCTRL_P2INTEN) && (s->sctl & SCTRL_P2INTEN)) {
+		new_status &= ~STAT_DAC2;
+	}
+
+	if (!(sctl & SCTRL_R1INTEN) && (s->sctl & SCTRL_R1INTEN)) {
+		new_status &= ~STAT_ADC;
+	}
+
+	if (new_status != s->status) {
+		es1370_update_status(s, new_status);
+	}
+}
+
+void CES1370::es1370_dac1_calc_freq(ES1370State* s, uint32_t ctl,
+	uint32_t* old_freq, uint32_t* new_freq)
+{
+	*old_freq = dac1_samplerate[(s->ctl & CTRL_WTSRSEL) >> CTRL_SH_WTSRSEL];
+	*new_freq = dac1_samplerate[(ctl & CTRL_WTSRSEL) >> CTRL_SH_WTSRSEL];
+}
+
+void CES1370::es1370_dac2_and_adc_calc_freq(ES1370State* s, uint32_t ctl,
+	uint32_t* old_freq,
+	uint32_t* new_freq)
+{
+	uint32_t old_pclkdiv, new_pclkdiv;
+
+	new_pclkdiv = (ctl & CTRL_PCLKDIV) >> CTRL_SH_PCLKDIV;
+	old_pclkdiv = (s->ctl & CTRL_PCLKDIV) >> CTRL_SH_PCLKDIV;
+	*new_freq = DAC2_DIVTOSR(new_pclkdiv);
+	*old_freq = DAC2_DIVTOSR(old_pclkdiv);
+}
+
+void CES1370::es1370_update_voices(ES1370State* s, uint32_t ctl, uint32_t sctl)
+{
+	size_t i;
+	uint32_t old_freq, new_freq, old_fmt, new_fmt;
+
+	for (i = 0; i < NB_CHANNELS; ++i) {
+		struct chan* d = &s->chan[i];
+		const struct chan_bits* b = &es1370_chan_bits[i];
+
+		new_fmt = (sctl & b->sctl_fmt) >> b->sctl_sh_fmt;
+		old_fmt = (s->sctl & b->sctl_fmt) >> b->sctl_sh_fmt;
+
+		b->calc_freq(s, ctl, &old_freq, &new_freq);
+		if ((old_fmt != new_fmt) || (old_freq != new_freq)) {
+			d->shift = (new_fmt & 1) + (new_fmt >> 1);
+			if (new_freq) {
+				//struct audsettings as;
+				SDL_AudioSpec as;
+
+				as.freq = new_freq;
+				as.channels = 1 << (new_fmt & 1);
+				as.format = (new_fmt & 2) ? SDL_AUDIO_S16LE : SDL_AUDIO_U8;
+
+				if (i == ADC_CHANNEL) {
+					SDL_SetAudioStreamFormat(s->adc_voice, &as, &as);
+				}
+				else {
+					SDL_SetAudioStreamFormat(s->dac_voice[i], &as, &as);
+				}
+			}
+		}
+
+		if (((ctl ^ s->ctl) & b->ctl_en) || ((sctl ^ s->sctl) & b->sctl_pause)) {
+			int on = (ctl & b->ctl_en) && !(sctl & b->sctl_pause);
+
+			if (i == ADC_CHANNEL) {
+				if (on) {
+					SDL_BindAudioStream(s->audio_be_in, s->adc_voice);
+				}
+				else {
+					SDL_UnbindAudioStream(s->adc_voice);
+				}
+			} else {
+				if (on) {
+					SDL_BindAudioStream(s->audio_be_out, s->dac_voice[i]);
+				}
+				else {
+					SDL_UnbindAudioStream(s->dac_voice[i]);
+				}
+			}
+		}
+	}
+
+    s->ctl = ctl;
+    s->sctl = sctl;
+}
+
+uint32_t CES1370::es1370_fixup(ES1370State* s, uint32_t addr)
+{
+	addr &= 0xff;
+	if (addr >= 0x30 && addr <= 0x3f) {
+		addr |= s->mempage << 8;
+	}
+	return addr;
+}
+
+void CES1370::es1370_write(void* opaque, u64 addr, uint64_t val, unsigned size)
+{
+    ES1370State* s = (ES1370State * )opaque;
+    struct chan* d = &s->chan[0];
+
+    addr = es1370_fixup(s, addr);
+
+    switch (addr) {
+    case ES1370_REG_CONTROL:
+        es1370_update_voices(s, val, s->sctl);
+        // print_ctl(val);
+        break;
+
+    case ES1370_REG_MEMPAGE:
+        s->mempage = val & 0xf;
+        break;
+
+    case ES1370_REG_SERIAL_CONTROL:
+        es1370_maybe_lower_irq(s, val);
+        es1370_update_voices(s, s->ctl, val);
+        // print_sctl(val);
+        break;
+
+    case ES1370_REG_DAC1_SCOUNT:
+    case ES1370_REG_DAC2_SCOUNT:
+    case ES1370_REG_ADC_SCOUNT:
+        d += (addr - ES1370_REG_DAC1_SCOUNT) >> 2;
+        d->scount = (val & 0xffff) << 16 | (val & 0xffff);
+        // trace_es1370_sample_count_wr(d - &s->chan[0],
+        //    d->scount >> 16, d->scount & 0xffff);
+        break;
+
+    case ES1370_REG_ADC_FRAMEADR:
+        d += 2;
+        goto frameadr;
+    case ES1370_REG_DAC1_FRAMEADR:
+    case ES1370_REG_DAC2_FRAMEADR:
+        d += (addr - ES1370_REG_DAC1_FRAMEADR) >> 3;
+    frameadr:
+        d->frame_addr = val;
+        //trace_es1370_frame_address_wr(d - &s->chan[0], d->frame_addr);
+        break;
+
+    case ES1370_REG_PHANTOM_FRAMECNT:
+        //lwarn("writing to phantom frame count 0x%" PRIx64, val);
+        break;
+    case ES1370_REG_PHANTOM_FRAMEADR:
+        //lwarn("writing to phantom frame address 0x%" PRIx64, val);
+        break;
+
+    case ES1370_REG_ADC_FRAMECNT:
+        d += 2;
+        goto framecnt;
+    case ES1370_REG_DAC1_FRAMECNT:
+    case ES1370_REG_DAC2_FRAMECNT:
+        d += (addr - ES1370_REG_DAC1_FRAMECNT) >> 3;
+    framecnt:
+        d->frame_cnt = val;
+        d->leftover = 0;
+        //trace_es1370_frame_count_wr(d - &s->chan[0],
+        //    d->frame_cnt >> 16, d->frame_cnt & 0xffff);
+        break;
+
+    default:
+        //lwarn("writel 0x%" PRIx64 " <- 0x%" PRIx64, addr, val);
+        break;
+    }
+}
+
+uint64_t CES1370::es1370_read(void* opaque, u64 addr, unsigned size)
+{
+    ES1370State* s = (ES1370State*)opaque;
+    uint32_t val;
+    struct chan* d = &s->chan[0];
+
+    addr = es1370_fixup(s, addr);
+
+    switch (addr) {
+    case ES1370_REG_CONTROL:
+        val = s->ctl;
+        break;
+    case ES1370_REG_STATUS:
+        val = s->status;
+        break;
+    case ES1370_REG_MEMPAGE:
+        val = s->mempage;
+        break;
+    case ES1370_REG_CODEC:
+        val = s->codec;
+        break;
+    case ES1370_REG_SERIAL_CONTROL:
+        val = s->sctl;
+        break;
+
+    case ES1370_REG_DAC1_SCOUNT:
+    case ES1370_REG_DAC2_SCOUNT:
+    case ES1370_REG_ADC_SCOUNT:
+        d += (addr - ES1370_REG_DAC1_SCOUNT) >> 2;
+        val = d->scount;
+        break;
+
+    case ES1370_REG_ADC_FRAMECNT:
+        d += 2;
+        goto framecnt;
+    case ES1370_REG_DAC1_FRAMECNT:
+    case ES1370_REG_DAC2_FRAMECNT:
+        d += (addr - ES1370_REG_DAC1_FRAMECNT) >> 3;
+    framecnt:
+        val = d->frame_cnt;
+        break;
+
+    case ES1370_REG_ADC_FRAMEADR:
+        d += 2;
+        goto frameadr;
+    case ES1370_REG_DAC1_FRAMEADR:
+    case ES1370_REG_DAC2_FRAMEADR:
+        d += (addr - ES1370_REG_DAC1_FRAMEADR) >> 3;
+    frameadr:
+        val = d->frame_addr;
+        break;
+
+    case ES1370_REG_PHANTOM_FRAMECNT:
+        val = ~0U;
+        //lwarn("reading from phantom frame count");
+        break;
+    case ES1370_REG_PHANTOM_FRAMEADR:
+        val = ~0U;
+        //lwarn("reading from phantom frame address");
+        break;
+
+    default:
+        val = ~0U;
+        //lwarn("readl 0x%" PRIx64 " -> 0x%x", addr, val);
+        break;
+    }
+    return val;
+}
+
+u32 CES1370::ReadMem_Bar(int func, int bar, u32 address, int dsize)
+{
+	printf("ReadMem_Bar func=%d bar=%d address=0x%08x dsize=%d\n", func, bar, address, dsize);
+    if (bar != 0) return ~0U;
+    if (dsize < 32) {
+        auto val = CES1370::ReadMem_Bar(func, bar, address & ~3, 32);
+        switch (dsize)
+        {
+        case 8:
+            return (val >> ((address & 3) * 8)) & 0xff;
+        case 16:
+            if (address & 2) {
+                return (val >> 16) & 0xffff;
+            }
+            else {
+                return val & 0xffff;
+            }
+        }
+    }
+    if (dsize == 32) {
+        return es1370_read(&s, address, dsize);
+    }
+    if (dsize == 64) {
+        uint64_t low = es1370_read(&s, address, 32);
+        uint64_t high = es1370_read(&s, address + 4, 32);
+        return low | (high << 32);
+	}
+    return ~0U;
+}
+
+void CES1370::WriteMem_Bar(int func, int bar, u32 address, int dsize, u32 data)
+{
+    if (bar != 0) return;
+
+	printf("WriteMem_Bar func=%d bar=%d address=0x%08x dsize=%d data=0x%08x\n", func, bar, address, dsize, data);
+    if (dsize < 32) {
+        auto val = CES1370::ReadMem_Bar(func, bar, address & ~3, 32);
+        switch (dsize)
+        {
+        case 8:
+        {
+			val = (val & ~(0xff << ((address & 3) * 8))) | ((data & 0xff) << ((address & 3) * 8));
+			CES1370::WriteMem_Bar(func, bar, address & ~3, 32, val);
+            return;
+        }
+        case 16:
+        {
+			if (address & 2) {
+                val = (val & 0xffff) | (data << 16);
+            }
+            else {
+                val = (val & 0xffff0000) | data;
+            }
+			CES1370::WriteMem_Bar(func, bar, address & ~3, 32, val);
+            return;
+        }
+        }
+    }
+
+	if (dsize == 32) {
+        es1370_write(&s, address, data, dsize);
+        return;
+    }
+
+    if (dsize == 64) {
+        es1370_write(&s, address, data & 0xffffffff, 32);
+        es1370_write(&s, address + 4, data >> 32, 32);
+        return;
+	}
+}
+
+void CES1370::es1370_transfer_audio(ES1370State* s, struct chan* d, int loop_sel,
+    int maxb, bool* irq)
+{
+    uint8_t tmpbuf[4096];
+    size_t to_transfer;
+    uint32_t addr = d->frame_addr;
+    int sc = d->scount & 0xffff;
+    int csc = d->scount >> 16;
+    int csc_bytes = (csc + 1) << d->shift;
+    int cnt = d->frame_cnt >> 16;
+    int size = d->frame_cnt & 0xffff;
+    if (size < cnt) {
+        return;
+    }
+    int left = ((size - cnt + 1) << 2) + d->leftover;
+    int transferred = 0;
+    int index = d - &s->chan[0];
+
+    to_transfer = min(maxb, min(left, csc_bytes));
+    addr += (cnt << 2) + d->leftover;
+
+    if (index == ADC_CHANNEL) {
+        while (to_transfer > 0) {
+            int acquired, to_copy;
+
+            to_copy = min(to_transfer, sizeof(tmpbuf));
+            //acquired = audio_be_read(s->audio_be, s->adc_voice, tmpbuf, to_copy);
+			acquired = SDL_GetAudioStreamData(s->adc_voice, tmpbuf, to_copy);
+            if (!acquired || acquired == -1) {
+                break;
+            }
+			do_pci_write(addr, tmpbuf, 1, acquired);
+
+            to_transfer -= acquired;
+            addr += acquired;
+            transferred += acquired;
+        }
+    }
+    else {
+        SDL_AudioStream* voice = s->dac_voice[index];
+
+        while (to_transfer > 0) {
+            int copied, to_copy;
+
+            to_copy = min(to_transfer, sizeof(tmpbuf));
+            //pci_dma_read(&s->dev, addr, tmpbuf, to_copy);
+			do_pci_read(addr, tmpbuf, 1, to_copy);
+            copied = SDL_PutAudioStreamData(voice, tmpbuf, to_copy) ? to_copy : 0;
+            if (!copied) {
+                break;
+            }
+            to_transfer -= copied;
+            addr += copied;
+            transferred += copied;
+        }
+    }
+
+    if (csc_bytes == transferred) {
+        if (*irq) {
+            //trace_es1370_lost_interrupt(index);
+        }
+        *irq = true;
+        d->scount = sc | (sc << 16);
+    }
+    else {
+        *irq = false;
+        d->scount = sc | (((csc_bytes - transferred - 1) >> d->shift) << 16);
+    }
+
+    cnt += (transferred + d->leftover) >> 2;
+
+    if (s->sctl & loop_sel) {
+        /*
+         * loop_sel tells us which bit in the SCTL register to look at
+         * (either P1_LOOP_SEL, P2_LOOP_SEL or R1_LOOP_SEL). The sense
+         * of these bits is 0 for loop mode (set interrupt and keep recording
+         * when the sample count reaches zero) or 1 for stop mode (set
+         * interrupt and stop recording).
+         */
+        //warn_report("es1370: non looping mode");
+    }
+    else {
+        d->frame_cnt = size;
+
+        if ((uint32_t)cnt <= d->frame_cnt) {
+            d->frame_cnt |= cnt << 16;
+        }
+    }
+
+    d->leftover = (transferred + d->leftover) & 3;
+}
+
+void CES1370::es1370_run_channel(ES1370State* s, size_t chan, int free_or_avail)
+{
+    uint32_t new_status = s->status;
+    int max_bytes;
+    bool irq;
+    struct chan* d = &s->chan[chan];
+    const struct chan_bits* b = &es1370_chan_bits[chan];
+
+    if (!(s->ctl & b->ctl_en) || (s->sctl & b->sctl_pause)) {
+        return;
+    }
+
+    max_bytes = free_or_avail;
+    max_bytes &= ~((1 << d->shift) - 1);
+    if (!max_bytes) {
+        return;
+    }
+
+    irq = s->sctl & b->sctl_inten && s->status & b->stat_int;
+
+    es1370_transfer_audio(s, d, b->sctl_loopsel, max_bytes, &irq);
+
+    if (irq) {
+        if (s->sctl & b->sctl_inten) {
+            new_status |= b->stat_int;
+        }
+    }
+
+    if (new_status != s->status) {
+        es1370_update_status(s, new_status);
+    }
+}
+
+void CES1370::es1370_dac_callback_dac1(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount)
+{
+    CES1370* dev = (CES1370*)userdata;
+    ES1370State* s = &dev->s;
+    dev->es1370_run_channel(s, 0, additional_amount);
+}
+
+void CES1370::es1370_dac_callback_dac2(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount)
+{
+    CES1370* dev = (CES1370*)userdata;
+    ES1370State* s = &dev->s;
+    dev->es1370_run_channel(s, 1, additional_amount);
+}
+
+void CES1370::es1370_dac_callback_adc(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount)
+{
+    CES1370* dev = (CES1370*)userdata;
+    ES1370State* s = &dev->s;
+    dev->es1370_run_channel(s, 2, additional_amount);
+}

--- a/src/ES1370.h
+++ b/src/ES1370.h
@@ -1,4 +1,4 @@
-
+#ifdef HAVE_SDL
 #include "StdAfx.h"
 #include "System.h"
 #include "SystemComponent.h"
@@ -196,3 +196,4 @@ private:
   static void es1370_dac_callback_dac2(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount);
   static void es1370_dac_callback_adc(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount);
 };
+#endif HAVE_SDL

--- a/src/ES1370.h
+++ b/src/ES1370.h
@@ -1,0 +1,198 @@
+
+#include "StdAfx.h"
+#include "System.h"
+#include "SystemComponent.h"
+#include "PCIDevice.h"
+
+#include <SDL3/SDL.h>
+/* Start blatant GPL violation */
+
+#define ES1370_REG_CONTROL        0x00
+#define ES1370_REG_STATUS         0x04
+#define ES1370_REG_UART_DATA      0x08
+#define ES1370_REG_UART_STATUS    0x09
+#define ES1370_REG_UART_CONTROL   0x09
+#define ES1370_REG_UART_TEST      0x0a
+#define ES1370_REG_MEMPAGE        0x0c
+#define ES1370_REG_CODEC          0x10
+#define ES1370_REG_SERIAL_CONTROL 0x20
+#define ES1370_REG_DAC1_SCOUNT    0x24
+#define ES1370_REG_DAC2_SCOUNT    0x28
+#define ES1370_REG_ADC_SCOUNT     0x2c
+
+#define ES1370_REG_DAC1_FRAMEADR    0xc30
+#define ES1370_REG_DAC1_FRAMECNT    0xc34
+#define ES1370_REG_DAC2_FRAMEADR    0xc38
+#define ES1370_REG_DAC2_FRAMECNT    0xc3c
+#define ES1370_REG_ADC_FRAMEADR     0xd30
+#define ES1370_REG_ADC_FRAMECNT     0xd34
+#define ES1370_REG_PHANTOM_FRAMEADR 0xd38
+#define ES1370_REG_PHANTOM_FRAMECNT 0xd3c
+
+static const unsigned dac1_samplerate[] = { 5512, 11025, 22050, 44100 };
+
+#define DAC2_SRTODIV(x) (((1411200+(x)/2)/(x))-2)
+#define DAC2_DIVTOSR(x) (1411200/((x)+2))
+
+#define CTRL_ADC_STOP   0x80000000  /* 1 = ADC stopped */
+#define CTRL_XCTL1      0x40000000  /* electret mic bias */
+#define CTRL_OPEN       0x20000000  /* no function, can be read and written */
+#define CTRL_PCLKDIV    0x1fff0000  /* ADC/DAC2 clock divider */
+#define CTRL_SH_PCLKDIV 16
+#define CTRL_MSFMTSEL   0x00008000  /* MPEG serial data fmt: 0 = Sony, 1 = I2S */
+#define CTRL_M_SBB      0x00004000  /* DAC2 clock: 0 = PCLKDIV, 1 = MPEG */
+#define CTRL_WTSRSEL    0x00003000  /* DAC1 clock freq: 0=5512, 1=11025, 2=22050, 3=44100 */
+#define CTRL_SH_WTSRSEL 12
+#define CTRL_DAC_SYNC   0x00000800  /* 1 = DAC2 runs off DAC1 clock */
+#define CTRL_CCB_INTRM  0x00000400  /* 1 = CCB "voice" ints enabled */
+#define CTRL_M_CB       0x00000200  /* recording source: 0 = ADC, 1 = MPEG */
+#define CTRL_XCTL0      0x00000100  /* 0 = Line in, 1 = Line out */
+#define CTRL_BREQ       0x00000080  /* 1 = test mode (internal mem test) */
+#define CTRL_DAC1_EN    0x00000040  /* enable DAC1 */
+#define CTRL_DAC2_EN    0x00000020  /* enable DAC2 */
+#define CTRL_ADC_EN     0x00000010  /* enable ADC */
+#define CTRL_UART_EN    0x00000008  /* enable MIDI uart */
+#define CTRL_JYSTK_EN   0x00000004  /* enable Joystick port (presumably at address 0x200) */
+#define CTRL_CDC_EN     0x00000002  /* enable serial (CODEC) interface */
+#define CTRL_SERR_DIS   0x00000001  /* 1 = disable PCI SERR signal */
+
+#define STAT_INTR       0x80000000  /* wired or of all interrupt bits */
+#define STAT_CSTAT      0x00000400  /* 1 = codec busy or codec write in progress */
+#define STAT_CBUSY      0x00000200  /* 1 = codec busy */
+#define STAT_CWRIP      0x00000100  /* 1 = codec write in progress */
+#define STAT_VC         0x00000060  /* CCB int source, 0=DAC1, 1=DAC2, 2=ADC, 3=undef */
+#define STAT_SH_VC      5
+#define STAT_MCCB       0x00000010  /* CCB int pending */
+#define STAT_UART       0x00000008  /* UART int pending */
+#define STAT_DAC1       0x00000004  /* DAC1 int pending */
+#define STAT_DAC2       0x00000002  /* DAC2 int pending */
+#define STAT_ADC        0x00000001  /* ADC int pending */
+
+#define USTAT_RXINT     0x80        /* UART rx int pending */
+#define USTAT_TXINT     0x04        /* UART tx int pending */
+#define USTAT_TXRDY     0x02        /* UART tx ready */
+#define USTAT_RXRDY     0x01        /* UART rx ready */
+
+#define UCTRL_RXINTEN   0x80        /* 1 = enable RX ints */
+#define UCTRL_TXINTEN   0x60        /* TX int enable field mask */
+#define UCTRL_ENA_TXINT 0x20        /* enable TX int */
+#define UCTRL_CNTRL     0x03        /* control field */
+#define UCTRL_CNTRL_SWR 0x03        /* software reset command */
+
+#define SCTRL_P2ENDINC    0x00380000  /*  */
+#define SCTRL_SH_P2ENDINC 19
+#define SCTRL_P2STINC     0x00070000  /*  */
+#define SCTRL_SH_P2STINC  16
+#define SCTRL_R1LOOPSEL   0x00008000  /* 0 = loop mode */
+#define SCTRL_P2LOOPSEL   0x00004000  /* 0 = loop mode */
+#define SCTRL_P1LOOPSEL   0x00002000  /* 0 = loop mode */
+#define SCTRL_P2PAUSE     0x00001000  /* 1 = pause mode */
+#define SCTRL_P1PAUSE     0x00000800  /* 1 = pause mode */
+#define SCTRL_R1INTEN     0x00000400  /* enable interrupt */
+#define SCTRL_P2INTEN     0x00000200  /* enable interrupt */
+#define SCTRL_P1INTEN     0x00000100  /* enable interrupt */
+#define SCTRL_P1SCTRLD    0x00000080  /* reload sample count register for DAC1 */
+#define SCTRL_P2DACSEN    0x00000040  /* 1 = DAC2 play back last sample when disabled */
+#define SCTRL_R1SEB       0x00000020  /* 1 = 16bit */
+#define SCTRL_R1SMB       0x00000010  /* 1 = stereo */
+#define SCTRL_R1FMT       0x00000030  /* format mask */
+#define SCTRL_SH_R1FMT    4
+#define SCTRL_P2SEB       0x00000008  /* 1 = 16bit */
+#define SCTRL_P2SMB       0x00000004  /* 1 = stereo */
+#define SCTRL_P2FMT       0x0000000c  /* format mask */
+#define SCTRL_SH_P2FMT    2
+#define SCTRL_P1SEB       0x00000002  /* 1 = 16bit */
+#define SCTRL_P1SMB       0x00000001  /* 1 = stereo */
+#define SCTRL_P1FMT       0x00000003  /* format mask */
+#define SCTRL_SH_P1FMT    0
+
+/* End blatant GPL violation */
+#define NB_CHANNELS 3
+#define DAC1_CHANNEL 0
+#define DAC2_CHANNEL 1
+#define ADC_CHANNEL 2
+
+
+class CES1370 : public CPCIDevice
+{
+public:
+  virtual int   SaveState(FILE* f) { return 0;  }
+  virtual int   RestoreState(FILE* f) { return 0;  }
+  virtual void  check_state() {}
+  virtual void  init();
+
+  virtual void  WriteMem_Bar(int func, int bar, u32 address, int dsize, u32 data);
+  virtual u32   ReadMem_Bar(int func, int bar, u32 address, int dsize);
+
+  CES1370(CConfigurator* cfg, class CSystem* c, int pcibus, int pcidev);
+  virtual ~CES1370();
+
+private:
+  struct chan {
+    uint32_t shift;
+    uint32_t leftover;
+    uint32_t scount;
+    uint32_t frame_addr;
+    uint32_t frame_cnt;
+  };
+
+  struct ES1370State {
+    SDL_AudioDeviceID audio_be_out;
+    SDL_AudioDeviceID audio_be_in;
+    struct chan chan[3];
+    SDL_AudioStream* dac_voice[2];
+    SDL_AudioStream* adc_voice;
+
+    uint32_t ctl;
+    uint32_t status;
+    uint32_t mempage;
+    uint32_t codec;
+    uint32_t sctl;
+  } s;
+
+  struct chan_bits {
+    uint32_t ctl_en;
+    uint32_t stat_int;
+    uint32_t sctl_pause;
+    uint32_t sctl_inten;
+    uint32_t sctl_fmt;
+    uint32_t sctl_sh_fmt;
+    uint32_t sctl_loopsel;
+    void (*calc_freq) (ES1370State* s, uint32_t ctl,
+      uint32_t* old_freq, uint32_t* new_freq);
+  };
+
+  static void es1370_dac1_calc_freq(ES1370State* s, uint32_t ctl,
+    uint32_t* old_freq, uint32_t* new_freq);
+
+  static void es1370_dac2_and_adc_calc_freq(ES1370State* s, uint32_t ctl,
+    uint32_t* old_freq,
+    uint32_t* new_freq);
+
+  struct chan_bits es1370_chan_bits[3] = {
+    {CTRL_DAC1_EN, STAT_DAC1, SCTRL_P1PAUSE, SCTRL_P1INTEN,
+     SCTRL_P1FMT, SCTRL_SH_P1FMT, SCTRL_P1LOOPSEL,
+     es1370_dac1_calc_freq},
+
+    {CTRL_DAC2_EN, STAT_DAC2, SCTRL_P2PAUSE, SCTRL_P2INTEN,
+     SCTRL_P2FMT, SCTRL_SH_P2FMT, SCTRL_P2LOOPSEL,
+     es1370_dac2_and_adc_calc_freq},
+
+    {CTRL_ADC_EN, STAT_ADC, 0, SCTRL_R1INTEN,
+     SCTRL_R1FMT, SCTRL_SH_R1FMT, SCTRL_R1LOOPSEL,
+     es1370_dac2_and_adc_calc_freq}
+  };
+  void es1370_update_status(ES1370State* s, uint32_t new_status);
+  void es1370_reset(ES1370State* s);
+  void es1370_maybe_lower_irq(ES1370State* s, uint32_t sctl);
+  void es1370_update_voices(ES1370State* s, uint32_t ctl, uint32_t sctl);
+  uint32_t es1370_fixup(ES1370State* s, uint32_t addr);
+  void es1370_write(void* opaque, u64 addr, uint64_t val, unsigned size);
+  uint64_t es1370_read(void* opaque, u64 addr, unsigned size);
+  void es1370_transfer_audio(ES1370State* s, struct chan* d, int loop_sel, int max, bool* irq);
+  void es1370_run_channel(ES1370State* s, size_t chan, int free_or_avail);
+
+  static void es1370_dac_callback_dac1(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount);
+  static void es1370_dac_callback_dac2(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount);
+  static void es1370_dac_callback_adc(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount);
+};

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,6 +71,7 @@ es40_SOURCES = AliM1543C.cpp \
        DMA.cpp \
        DPR.cpp \
        es40_debug.cpp \
+       ES1370.cpp \
        Ethernet.cpp \
        Flash.cpp \
        FloppyController.cpp \

--- a/src/Visual Studio/es40.vcxproj
+++ b/src/Visual Studio/es40.vcxproj
@@ -1465,6 +1465,7 @@
     <ClCompile Include="..\Cirrus.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\ES1370.cpp" />
     <ClCompile Include="..\MPU401.cpp" />
     <ClCompile Include="..\Configurator.cpp" />
     <ClCompile Include="..\DEC21143.cpp" />
@@ -1550,6 +1551,7 @@
     <ClInclude Include="..\DMA.h" />
     <ClInclude Include="..\DPR.h" />
     <ClInclude Include="..\emu\emu.h" />
+    <ClInclude Include="..\ES1370.h" />
     <ClInclude Include="..\es40_debug.h" />
     <ClInclude Include="..\es40_endian.h" />
     <ClInclude Include="..\Ethernet.h" />

--- a/src/Visual Studio/es40.vcxproj.filters
+++ b/src/Visual Studio/es40.vcxproj.filters
@@ -183,6 +183,9 @@
     <ClCompile Include="..\MPU401.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\ES1370.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\AliM1543C.h">
@@ -423,6 +426,9 @@
       <Filter>Header Files\base</Filter>
     </ClInclude>
     <ClInclude Include="..\MPU401.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ES1370.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/es40-cfg.cpp
+++ b/src/es40-cfg.cpp
@@ -765,6 +765,7 @@ int main(int argc, char* argv[])
 #endif
 	card_q.addAnswer("scsi", "sym53c810", "Symbios 53C810 narrow SCSI controller");
 	card_q.addAnswer("wide scsi", "sym53c895", "Symbios 53C895 wide SCSI controller (doesn't work with OpenVMS)");
+	card_q.addAnswer("es1370 audio", "es1370", "ES1370 Audio card (works only with Windows NT 4.0)");
 
 	/* Loop until there are no more PCI
 	 * cards to add.


### PR DESCRIPTION
Adds ES1370 emulation using SDL3 audio backend. Currently the recording device has to remain open because of the emulation being a straight port from QEMU, and some pop artefacts remain present since the callbacks are not buffered yet.