### PR TITLE
PCIDevice: Fix out-of-bound crashes on busmaster operations

### DIFF
--- a/src/ES1370.cpp
+++ b/src/ES1370.cpp
@@ -425,7 +425,6 @@ uint64_t CES1370::es1370_read(void* opaque, u64 addr, unsigned size)
 
 u32 CES1370::ReadMem_Bar(int func, int bar, u32 address, int dsize)
 {
-	printf("ReadMem_Bar func=%d bar=%d address=0x%08x dsize=%d\n", func, bar, address, dsize);
     if (bar != 0) return ~0U;
     if (dsize < 32) {
         auto val = CES1370::ReadMem_Bar(func, bar, address & ~3, 32);
@@ -457,7 +456,6 @@ void CES1370::WriteMem_Bar(int func, int bar, u32 address, int dsize, u32 data)
 {
     if (bar != 0) return;
 
-	printf("WriteMem_Bar func=%d bar=%d address=0x%08x dsize=%d data=0x%08x\n", func, bar, address, dsize, data);
     if (dsize < 32) {
         auto val = CES1370::ReadMem_Bar(func, bar, address & ~3, 32);
         switch (dsize)

--- a/src/PCIDevice.cpp
+++ b/src/PCIDevice.cpp
@@ -668,11 +668,12 @@ void CPCIDevice::do_pci_read(u32 address, void* dest, size_t element_size,
 
 			// get a pointer to system memory if the address is inside main memory
 			char* memptr = cSystem->PtrToMem(cur_phys);
+			char* memptr2 = cSystem->PtrToMem(cur_phys + chunk - 1);
 
 			// Copy only within a single translated DMA page. Scatter-gather DMA does
 			// not guarantee that adjacent PCI bus addresses map to contiguous host
 			// physical memory beyond the current page.
-			if (memptr)
+			if (memptr && memptr2)
 			{
 				memcpy(dst, memptr, chunk);
 			}
@@ -776,11 +777,13 @@ void CPCIDevice::do_pci_write(u32 address, void* source, size_t element_size,
 
 			// get a pointer to system memory if the address is inside main memory
 			char* memptr = cSystem->PtrToMem(cur_phys);
+			char* memptr2 = cSystem->PtrToMem(cur_phys + chunk - 1);
 
 			// Copy only within a single translated DMA page. Scatter-gather DMA does
 			// not guarantee that adjacent PCI bus addresses map to contiguous host
 			// physical memory beyond the current page.
-			if (memptr)
+			// Also, make sure we aren't trying to copy past allocated memory.
+			if (memptr && memptr2)
 			{
 				memcpy(memptr, src, chunk);
 			}


### PR DESCRIPTION
Avoid doing out-of-bound reads/writes from/to system memory. Fixes emulator crashing during Tru64 boots.

Drive-by: Remove logging on memory reads/writes from ES1370.