### PR TITLE
FDC: Initialize some internal structures upon reset

### DIFF
--- a/src/FloppyController.cpp
+++ b/src/FloppyController.cpp
@@ -208,7 +208,10 @@ void CFloppyController::WriteMem(int index, u64 address, int dsize, u64 data)
 			state.cmd_res_max = 0;
 			state.status.rqm = 1;
 			state.status.dio = 0;
+			state.status.nondma = !state.dma;
 			state.reset_sense_cnt = 0;
+			state.drive[0].seeking = 0;
+			state.drive[1].seeking = 0;
             			clear_interrupt();
        		} else if ((old_dor & 0x04) == 0) {
 			state.reset_sense_cnt = 4;


### PR DESCRIPTION
Some C++ compilers won't zero initialize private structures. As such like OpenVMS boots till
`%LOADER-I-INIT, initializing SYS$DVDRIVER.EXE`
will resulting this error
```
**** OpenVMS Alpha Operating System V8.4     - BUGCHECK ****

** Bugcheck code = 0000019C: INCONSTATE, Inconsistent I/O data base
** Crash CPU: 00000000    Primary CPU: 00000000
** Highest CPU number:    00000003
** Active CPUs:           00000000.00000001
** Current Process:       STARTUP
** Current PSB ID:        00000001
** Image Name:            DQB0:[SYS0.SYSCOMMON.][SYSEXE]SYSMAN.EXE;1
```

Meanwhile on the emulator console:
```
FDC:  motor a: off, motor b: off, dma: on, drive: A
FDC:  motor a: off, motor b: off, dma: on, drive: A
FDC: data rate 500 Kb/S MFM
FDC Status: Data Register Ready, S->C, No DMA, BUSY, Disk 1 Seeking, Disk 0 Seeking
FDC: Read register 4, value: f3
FDC: Read register 5, value: ff
FDC Status: Data Register Ready, S->C, No DMA, BUSY, Disk 1 Seeking, Disk 0 Seeking
FDC: Read register 4, value: f3
FDC: Read register 5, value: ff
FDC Status: Data Register Ready, S->C, No DMA, BUSY, Disk 1 Seeking, Disk 0 Seeking
FDC: Read register 4, value: f3
FDC: Read register 5, value: ff
FDC Status: Data Register Ready, S->C, No DMA, BUSY, Disk 1 Seeking, Disk 0 Seeking
FDC: Read register 4, value: f3
FDC: Read register 5, value: ff
FDC Status: Data Register Ready, S->C, No DMA, BUSY, Disk 1 Seeking, Disk 0 Seeking
FDC: Read register 4, value: f3
FDC: Read register 5, value: ff
...
```
instead the correct sequences
```
FDC:  motor a: off, motor b: off, dma: on, drive: A
FDC:  motor a: off, motor b: off, dma: on, drive: A
FDC: data rate 500 Kb/S MFM
FDC Status: Data Register Ready, S->C, DMA, not busy, Disk 1 Idle, Disk 0 Idle
FDC: Read register 4, value: 80
FDC Status: Data Register Ready, S->C, DMA, not busy, Disk 1 Idle, Disk 0 Idle
FDC: Read register 4, value: 80
FDC: command Sense Interrupt Status()
FDC Status: Data Register Ready, C->S, DMA, BUSY, Disk 1 Idle, Disk 0 Idle
FDC: Read register 4, value: d0
FDC: Read register 5, value: 20
FDC Status: Data Register Ready, C->S, DMA, BUSY, Disk 1 Idle, Disk 0 Idle
FDC: Read register 4, value: d0
FDC: Read register 5, value: ff
FDC Status: Data Register Ready, S->C, DMA, not busy, Disk 1 Idle, Disk 0 Idle
FDC: Read register 4, value: 80
FDC Status: Data Register Ready, S->C, DMA, not busy, Disk 1 Idle, Disk 0 Idle
FDC: Read register 4, value: 80
FDC: command Sense Interrupt Status()
...
```

So proposal this fix.