### PR TITLE
Switch PCap linking on Windows to be fully dynamic and optional and f…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -434,3 +434,8 @@ src/es40_idb
 src/es40_cfg
 src/es40_lss
 src/es40_lsm
+
+build
+build/
+build/*
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,10 @@ endif()
 
 if (NOT ES40_DISABLE_NETWORKING)
     if (WIN32)
-        if (NOT NPCAP_DIR)
-            set(NPCAP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../NPCAP")
-        endif()
-        find_package(NPCap REQUIRED)
+        #if (NOT NPCAP_DIR)
+        #    set(NPCAP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../NPCAP")
+        #endif()
+        #find_package(NPCap REQUIRED)
     else()
         find_package(PCap REQUIRED)
     endif()
@@ -41,10 +41,14 @@ list(APPEND ES40_CFG_SOURCES
     src/base/Exception.cpp
     )
 
+if (WIN32)
+    list(APPEND ES40_CFG_LIBRARIES winmm)
+endif()
+
 if (NOT ES40_DISABLE_NETWORKING)
     list(APPEND ES40_CFG_DEFINITIONS HAVE_PCAP)
     if (WIN32)
-        list(APPEND ES40_CFG_LIBRARIES NPCap::NPCap)
+        #list(APPEND ES40_CFG_LIBRARIES NPCap::NPCap)
     else()
         list(APPEND ES40_CFG_LIBRARIES PCap::PCap)
     endif()
@@ -138,6 +142,7 @@ if (NOT ES40_DISABLE_SDL)
         list(APPEND ES40_SOURCES
             src/gui/gui_win32.cpp
             )
+        list(APPEND ES40_LIBRARIES winmm)
     else()
         list(APPEND ES40_SOURCES
             src/gui/gui_x11.cpp
@@ -148,7 +153,7 @@ endif()
 if (NOT ES40_DISABLE_NETWORKING)
     list(APPEND ES40_DEFINITIONS HAVE_PCAP)
     if (WIN32)
-        list(APPEND ES40_LIBRARIES NPCap::NPCap)
+        # list(APPEND ES40_LIBRARIES NPCap::NPCap)
     else()
         list(APPEND ES40_LIBRARIES PCap::PCap)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ target_link_libraries(es40-cfg PRIVATE
     ${ES40_CFG_LIBRARIES}
     )
 
+target_compile_definitions(es40-cfg PUBLIC ${ES40_CFG_DEFINITIONS})
+
 set_property(TARGET es40-cfg PROPERTY CXX_STANDARD 17)
 
 ############################### ES40 ###############################

--- a/src/DEC21143.cpp
+++ b/src/DEC21143.cpp
@@ -418,11 +418,80 @@ u32             dec21143_cfg_mask[64] = {
 
 int CDEC21143::nic_num = 0;
 
+#ifdef _WIN32
+/* Pointers to the real functions. */
+static const char *(*f_pcap_lib_version)(void);
+static int (*f_pcap_findalldevs)(pcap_if_t **, char *);
+static void (*f_pcap_freealldevs)(void *);
+static pcap_t* (*f_pcap_open_live)(const char *, int, int, int, char *);
+static int (*f_pcap_compile)(void *, void *, const char *, int, bpf_u_int32);
+static int (*f_pcap_setfilter)(void *, void *);
+static const unsigned char
+    *(*f_pcap_next)(void *, void *);
+static int (*f_pcap_sendpacket)(void *, const unsigned char *, int);
+static void (*f_pcap_close)(void *);
+static int (*f_pcap_setnonblock)(void *, int, char *);
+static int (*f_pcap_set_immediate_mode)(void *, int);
+static int (*f_pcap_set_promisc)(void *, int);
+static int (*f_pcap_set_snaplen)(void *, int);
+static int (*f_pcap_dispatch)(void *, int, pcap_handler callback, unsigned char *user);
+static void *(*f_pcap_create)(const char *, char *);
+static int (*f_pcap_activate)(void *);
+static void *(*f_pcap_geterr)(void *);
+static pcap_t* (*f_pcap_open)(const char *source, int snaplen, int flags, int read_timeout, struct pcap_rmtauth *auth, char *errbuf);
+static int (*f_pcap_next_ex)(pcap_t *, struct pcap_pkthdr **, const unsigned char **);
+#endif
+
 /**
  * Constructor.
  **/
 CDEC21143::CDEC21143(CConfigurator* confg, CSystem* c, int pcibus, int pcidev) : CPCIDevice(confg, c, pcibus, pcidev), mySemaphore(0, 1)
 {
+#ifdef _WIN32
+	{
+	    char npcap_dir[512];
+    	GetSystemDirectoryA(npcap_dir, 480);
+    	strcat(npcap_dir, "\\Npcap");
+    	SetDllDirectoryA(npcap_dir);	
+		auto libhandle = LoadLibraryA("wpcap.dll");
+    	SetDllDirectoryA(NULL); /* reset the DLL search path */
+		if (!libhandle) {
+			FAILURE(Runtime, "Failed to load wpcap.dll");
+		}
+		f_pcap_lib_version = (const char *(*)())GetProcAddress(libhandle, "pcap_lib_version");
+		f_pcap_findalldevs = (int (*)(pcap_if_t **, char *))GetProcAddress(libhandle, "pcap_findalldevs");
+		f_pcap_freealldevs = (void (*)(void *))GetProcAddress(libhandle, "pcap_freealldevs");
+		f_pcap_open_live   = (pcap_t *(*)(const char *, int, int, int, char *))GetProcAddress(libhandle, "pcap_open_live");
+		f_pcap_open   = (pcap_t* (*)(const char *, int , int , int , pcap_rmtauth *, char *))GetProcAddress(libhandle, "pcap_open");
+		f_pcap_compile = (int (*)(void *, void *, const char *, int, bpf_u_int32))GetProcAddress(libhandle, "pcap_compile");
+		f_pcap_setfilter = (int (*)(void *, void *))GetProcAddress(libhandle, "pcap_setfilter");
+		f_pcap_next = (const unsigned char *(*)(void *, void *))GetProcAddress(libhandle, "pcap_next");
+		f_pcap_sendpacket = (int (*)(void *, const unsigned char *, int))GetProcAddress(libhandle, "pcap_sendpacket");
+		f_pcap_close = (void (*)(void *))GetProcAddress(libhandle, "pcap_close");
+		f_pcap_setnonblock = (int (*)(void *, int, char *))GetProcAddress(libhandle, "pcap_setnonblock");
+		f_pcap_set_immediate_mode = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_immediate_mode");
+		f_pcap_set_promisc = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_promisc");
+		f_pcap_set_snaplen = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_snaplen");
+		f_pcap_dispatch = (int (*)(void *, int, pcap_handler callback, unsigned char *user))GetProcAddress(libhandle, "pcap_dispatch");
+		f_pcap_create = (void * (*)(const char *, char *))GetProcAddress(libhandle, "pcap_create");
+		f_pcap_geterr = (void *(*)(void *))GetProcAddress(libhandle, "pcap_geterr");
+		f_pcap_next_ex = (int (*)(pcap *, pcap_pkthdr **, const unsigned char **))GetProcAddress(libhandle, "pcap_next_ex");
+
+		#define pcap_findalldevs f_pcap_findalldevs
+		#define pcap_open f_pcap_open
+		#define pcap_sendpacket f_pcap_sendpacket
+		#define pcap_close f_pcap_close
+		#define pcap_setnonblock f_pcap_setnonblock
+		#define pcap_setfilter f_pcap_setfilter
+		#define pcap_compile f_pcap_compile
+		#define pcap_geterr f_pcap_geterr
+		#define pcap_next_ex f_pcap_next_ex
+
+		#define PCAP_ERROR -1
+		#define PCAP_OPENFLAG_PROMISCUOUS 0x00000001
+		#define PCAP_OPENFLAG_NOCAPTURE_LOCAL 0x00000008
+	}
+#endif
 }
 
 /**
@@ -433,8 +502,8 @@ void CDEC21143::init()
 	pcap_if_t* alldevs;
 
 	pcap_if_t* d;
-	u_int       inum;
-	u_int       i = 0;
+	unsigned int inum;
+	unsigned int i = 0;
 	char        errbuf[PCAP_ERRBUF_SIZE];
 	char* cfg;
 
@@ -477,13 +546,13 @@ void CDEC21143::init()
 				if (fgets(input_buf, sizeof(input_buf), stdin) == NULL)
 					FAILURE(Runtime, "Unexpected end of input while selecting network interface");
 
-				if (sscanf(input_buf, "%d", &parsed) != 1 || parsed < 1 || (u_int)parsed > i)
+				if (sscanf(input_buf, "%d", &parsed) != 1 || parsed < 1 || (unsigned int)parsed > i)
 				{
 					printf("%%NIC-W-BADSEL: Invalid selection. Please enter a number between 1 and %d.\n", i);
 					continue;
 				}
 
-				inum = (u_int)parsed;
+				inum = (unsigned int)parsed;
 				break;
 			}
 		}
@@ -507,7 +576,7 @@ void CDEC21143::init()
 	//            and will panic on startup and abort.
 	//    4. Libpcap doesn't reflect packets, and we want winpcap/libpcap processing to be identical.
 	// Loopback packets are handled via direct entry in the receive queue.
-	if ((fp = pcap_open(cfg, 65536 /*snaplen: capture entire packets */,
+	if ((fp = (pcap_t*)pcap_open(cfg, 65536 /*snaplen: capture entire packets */,
 		PCAP_OPENFLAG_PROMISCUOUS | PCAP_OPENFLAG_NOCAPTURE_LOCAL /*promiscuous */,
 		10 /*packet buffer timeout: [ms] */, 0 /* auth structure */, errbuf)) == NULL) // connect to pcap...
 #else
@@ -682,7 +751,7 @@ void CDEC21143::check_state()
 void CDEC21143::receive_process()
 {
 	struct pcap_pkthdr* packet_header;
-	const u_char* packet_data = NULL;
+	const unsigned char* packet_data = NULL;
 
 	// if receive process active
 	if (state.reg[CSR_OPMODE / 8] & OPMODE_SR)

--- a/src/DEC21143.h
+++ b/src/DEC21143.h
@@ -96,10 +96,68 @@
 #include "DEC21143_tulipreg.h"
 #if defined(WIN32)
 #define HAVE_REMOTE
-#endif
+#else
 #include <pcap.h>
+#endif
 #include "Ethernet.h"
 #include "base/Semaphore.h"
+
+#if defined(WIN32)
+typedef int          bpf_int32;
+typedef unsigned int bpf_u_int32;
+
+/*
+ * The instruction data structure.
+ */
+struct bpf_insn {
+    unsigned short code;
+    unsigned char  jt;
+    unsigned char  jf;
+    bpf_u_int32    k;
+};
+
+/*
+ * Structure for "pcap_compile()", "pcap_setfilter()", etc..
+ */
+struct bpf_program {
+    unsigned int     bf_len;
+    struct bpf_insn *bf_insns;
+};
+
+typedef struct pcap_if pcap_if_t;
+
+#    define PCAP_ERRBUF_SIZE 256
+
+struct pcap_pkthdr {
+    struct timeval ts;
+    bpf_u_int32    caplen;
+    bpf_u_int32    len;
+};
+
+struct pcap_if {
+    struct pcap_if *next;
+    char           *name;
+    char           *description;
+    void           *addresses;
+    bpf_u_int32     flags;
+};
+
+struct pcap_send_queue {
+    unsigned int maxlen; /* Maximum size of the queue, in bytes. This
+             variable contains the size of the buffer field. */
+    unsigned int len;    /* Current size of the queue, in bytes. */
+    char *buffer; /* Buffer containing the packets to be sent. */
+};
+
+typedef struct pcap_send_queue pcap_send_queue;
+
+typedef void (*pcap_handler)(unsigned char *user, const struct pcap_pkthdr *h, const unsigned char *bytes);
+
+typedef struct pcap pcap_t;
+typedef struct pcap_dumper pcap_dumper_t;
+typedef struct pcap_if pcap_if_t;
+typedef struct pcap_addr pcap_addr_t;
+#endif
 
   /**
    * \brief Emulated DEC 21143 NIC device.

--- a/src/DEC21143.h
+++ b/src/DEC21143.h
@@ -96,6 +96,7 @@
 #include "DEC21143_tulipreg.h"
 #if defined(WIN32)
 #define HAVE_REMOTE
+#include <winsock.h>
 #else
 #include <pcap.h>
 #endif

--- a/src/ES1370.cpp
+++ b/src/ES1370.cpp
@@ -484,12 +484,6 @@ void CES1370::WriteMem_Bar(int func, int bar, u32 address, int dsize, u32 data)
         es1370_write(&s, address, data, dsize);
         return;
     }
-
-    if (dsize == 64) {
-        es1370_write(&s, address, data & 0xffffffff, 32);
-        es1370_write(&s, address + 4, data >> 32, 32);
-        return;
-	}
 }
 
 void CES1370::es1370_transfer_audio(ES1370State* s, struct chan* d, int loop_sel,
@@ -637,4 +631,4 @@ void CES1370::es1370_dac_callback_adc(void* userdata, SDL_AudioStream* stream, i
     ES1370State* s = &dev->s;
     dev->es1370_run_channel(s, 2, additional_amount);
 }
-#endif HAVE_SDL
+#endif /* HAVE_SDL */

--- a/src/ES1370.h
+++ b/src/ES1370.h
@@ -196,4 +196,4 @@ private:
   static void es1370_dac_callback_dac2(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount);
   static void es1370_dac_callback_adc(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount);
 };
-#endif HAVE_SDL
+#endif /* HAVE_SDL */

--- a/src/MPU401.h
+++ b/src/MPU401.h
@@ -53,7 +53,7 @@ public:
     c->RegisterMemory(this, 1, U64(0x00000801fc000331), 1);
   }
 
-  virtual CMPU401::~CMPU401()
+  virtual ~CMPU401()
   {
     midiOutClose(hmo);
   }

--- a/src/Serial.h
+++ b/src/Serial.h
@@ -165,8 +165,8 @@ private:
     bool  irq_active;
   } state;
   int listenPort;
-  int listenSocket;
-  int connectSocket;
+  int64_t listenSocket;
+  int64_t connectSocket;
   bool disabled = false;     ///< If true, port is not exposed to guest; reads return 0xff, writes ignored. Used to skip KDCOM probe on AXP64 2210 etc.
   bool raw_mode = false;     ///< If true, skip telnet IAC processing and connect banner. Use for windbg/kgdb where the byte stream must be 8-bit clean.
   bool null_attach = false;  ///< If true, port exists on the bus but no socket is opened and no I/O thread runs.

--- a/src/base/Thread.h
+++ b/src/base/Thread.h
@@ -242,7 +242,7 @@ private:
 
   void applyPriority()
   {
-    HANDLE h = static_cast<HANDLE>(_thread.native_handle());
+    HANDLE h = (HANDLE)(_thread.native_handle());
     if (!SetThreadPriority(h, mapPrioWin32(_prio)))
       printf("Warning: SetThreadPriority failed for thread '%s' (error %lu)\n",
         _name.c_str(), GetLastError());

--- a/src/config_win32.h
+++ b/src/config_win32.h
@@ -308,21 +308,7 @@
             /* #undef inline */
 #endif
 
-/* Define to the type of a signed integer type of width exactly 16 bits if
-   such a type exists and the standard includes do not define it. */
-typedef signed __int16 int16_t;
-
-/* Define to the type of a signed integer type of width exactly 32 bits if
-   such a type exists and the standard includes do not define it. */
-typedef signed __int32 int32_t;
-
-/* Define to the type of a signed integer type of width exactly 64 bits if
-   such a type exists and the standard includes do not define it. */
-typedef signed __int64 int64_t;
-
-/* Define to the type of a signed integer type of width exactly 8 bits if such
-   a type exists and the standard includes do not define it. */
-typedef signed __int8 int8_t;
+#include <stdint.h>
 
 /* Define to rpl_malloc if the replacement function should be used. */
 /* #undef malloc */
@@ -338,22 +324,6 @@ typedef signed __int8 int8_t;
 
 /* Define to `int' if <sys/types.h> does not define. */
 /* #undef ssize_t */
-
-/* Define to the type of an unsigned integer type of width exactly 16 bits if
-   such a type exists and the standard includes do not define it. */
-typedef unsigned __int16 uint16_t;
-
-/* Define to the type of an unsigned integer type of width exactly 32 bits if
-   such a type exists and the standard includes do not define it. */
-typedef unsigned __int32 uint32_t;
-
-/* Define to the type of an unsigned integer type of width exactly 64 bits if
-   such a type exists and the standard includes do not define it. */
-typedef unsigned __int64 uint64_t;
-
-/* Define to the type of an unsigned integer type of width exactly 8 bits if
-   such a type exists and the standard includes do not define it. */
-typedef unsigned __int8 uint8_t;
 
 /* Define as `fork' if `vfork' does not work. */
 /* #undef vfork */

--- a/src/config_win32.h
+++ b/src/config_win32.h
@@ -308,8 +308,6 @@
             /* #undef inline */
 #endif
 
-#include <stdint.h>
-
 /* Define to rpl_malloc if the replacement function should be used. */
 /* #undef malloc */
 
@@ -329,15 +327,13 @@
 /* #undef vfork */
 
 #ifndef _WIN32_WINNT
-#define _WIN32_WINNT  0x400
+#define _WIN32_WINNT  0x0502
 #endif
 
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 
 #define _CRT_SECURE_NO_DEPRECATE  1
 
-#if _MSC_VER < 1400
-#define WINVER  0x0400
-#else
-#define WINVER  0x0501
-#endif
+#define WINVER  0x0502
+
+#include <stdint.h>

--- a/src/datatypes.h
+++ b/src/datatypes.h
@@ -111,7 +111,7 @@
 
 #if defined(_WIN32) && !defined(__GNUWIN32__)
 
-#define U64(a)  a##ui64
+#define U64(a)  a##ull
 
 #else // defined(_WIN32)
 

--- a/src/es40-cfg.cpp
+++ b/src/es40-cfg.cpp
@@ -68,7 +68,86 @@
 #include <algorithm>
 
 #if defined(HAVE_PCAP)
+#ifdef _WIN32
+typedef int          bpf_int32;
+typedef unsigned int bpf_u_int32;
+
+/*
+ * The instruction data structure.
+ */
+struct bpf_insn {
+    unsigned short code;
+    unsigned char  jt;
+    unsigned char  jf;
+    bpf_u_int32    k;
+};
+
+/*
+ * Structure for "pcap_compile()", "pcap_setfilter()", etc..
+ */
+struct bpf_program {
+    unsigned int     bf_len;
+    struct bpf_insn *bf_insns;
+};
+
+typedef struct pcap_if pcap_if_t;
+
+#    define PCAP_ERRBUF_SIZE 256
+
+struct pcap_pkthdr {
+    struct timeval ts;
+    bpf_u_int32    caplen;
+    bpf_u_int32    len;
+};
+
+struct pcap_if {
+    struct pcap_if *next;
+    char           *name;
+    char           *description;
+    void           *addresses;
+    bpf_u_int32     flags;
+};
+
+struct pcap_send_queue {
+    unsigned int maxlen; /* Maximum size of the queue, in bytes. This
+             variable contains the size of the buffer field. */
+    unsigned int len;    /* Current size of the queue, in bytes. */
+    char *buffer; /* Buffer containing the packets to be sent. */
+};
+
+typedef struct pcap_send_queue pcap_send_queue;
+
+typedef void (*pcap_handler)(unsigned char *user, const struct pcap_pkthdr *h, const unsigned char *bytes);
+
+typedef struct pcap pcap_t;
+typedef struct pcap_dumper pcap_dumper_t;
+typedef struct pcap_if pcap_if_t;
+typedef struct pcap_addr pcap_addr_t;
+
+/* Pointers to the real functions. */
+static const char *(*f_pcap_lib_version)(void);
+static int (*f_pcap_findalldevs)(pcap_if_t **, char *);
+static void (*f_pcap_freealldevs)(void *);
+static pcap_t* (*f_pcap_open_live)(const char *, int, int, int, char *);
+static int (*f_pcap_compile)(void *, void *, const char *, int, bpf_u_int32);
+static int (*f_pcap_setfilter)(void *, void *);
+static const unsigned char
+    *(*f_pcap_next)(void *, void *);
+static int (*f_pcap_sendpacket)(void *, const unsigned char *, int);
+static void (*f_pcap_close)(void *);
+static int (*f_pcap_setnonblock)(void *, int, char *);
+static int (*f_pcap_set_immediate_mode)(void *, int);
+static int (*f_pcap_set_promisc)(void *, int);
+static int (*f_pcap_set_snaplen)(void *, int);
+static int (*f_pcap_dispatch)(void *, int, pcap_handler callback, unsigned char *user);
+static void *(*f_pcap_create)(const char *, char *);
+static int (*f_pcap_activate)(void *);
+static void *(*f_pcap_geterr)(void *);
+static pcap_t* (*f_pcap_open)(const char *source, int snaplen, int flags, int read_timeout, struct pcap_rmtauth *auth, char *errbuf);
+static int (*f_pcap_next_ex)(pcap_t *, struct pcap_pkthdr **, const unsigned char **);
+#else
 #include <pcap.h>
+#endif
 #endif
 
 using namespace std;
@@ -296,6 +375,50 @@ int main(int argc, char* argv[])
 {
 	/* Banner
 	 */
+#if defined _WIN32 && defined HAVE_PCAP
+	    char npcap_dir[512];
+    	GetSystemDirectoryA(npcap_dir, 480);
+    	strcat(npcap_dir, "\\Npcap");
+    	SetDllDirectoryA(npcap_dir);	
+		auto libhandle = LoadLibraryA("wpcap.dll");
+    	SetDllDirectoryA(NULL); /* reset the DLL search path */
+		if (!libhandle) {
+			printf("Failed to load wpcap.dll");
+			return -1;
+		}
+		f_pcap_lib_version = (const char *(*)())GetProcAddress(libhandle, "pcap_lib_version");
+		f_pcap_findalldevs = (int (*)(pcap_if_t **, char *))GetProcAddress(libhandle, "pcap_findalldevs");
+		f_pcap_freealldevs = (void (*)(void *))GetProcAddress(libhandle, "pcap_freealldevs");
+		f_pcap_open_live   = (pcap_t *(*)(const char *, int, int, int, char *))GetProcAddress(libhandle, "pcap_open_live");
+		f_pcap_open   = (pcap_t* (*)(const char *, int , int , int , pcap_rmtauth *, char *))GetProcAddress(libhandle, "pcap_open");
+		f_pcap_compile = (int (*)(void *, void *, const char *, int, bpf_u_int32))GetProcAddress(libhandle, "pcap_compile");
+		f_pcap_setfilter = (int (*)(void *, void *))GetProcAddress(libhandle, "pcap_setfilter");
+		f_pcap_next = (const unsigned char *(*)(void *, void *))GetProcAddress(libhandle, "pcap_next");
+		f_pcap_sendpacket = (int (*)(void *, const unsigned char *, int))GetProcAddress(libhandle, "pcap_sendpacket");
+		f_pcap_close = (void (*)(void *))GetProcAddress(libhandle, "pcap_close");
+		f_pcap_setnonblock = (int (*)(void *, int, char *))GetProcAddress(libhandle, "pcap_setnonblock");
+		f_pcap_set_immediate_mode = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_immediate_mode");
+		f_pcap_set_promisc = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_promisc");
+		f_pcap_set_snaplen = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_snaplen");
+		f_pcap_dispatch = (int (*)(void *, int, pcap_handler callback, unsigned char *user))GetProcAddress(libhandle, "pcap_dispatch");
+		f_pcap_create = (void * (*)(const char *, char *))GetProcAddress(libhandle, "pcap_create");
+		f_pcap_geterr = (void *(*)(void *))GetProcAddress(libhandle, "pcap_geterr");
+		f_pcap_next_ex = (int (*)(pcap *, pcap_pkthdr **, const unsigned char **))GetProcAddress(libhandle, "pcap_next_ex");
+
+		#define pcap_findalldevs f_pcap_findalldevs
+		#define pcap_open f_pcap_open
+		#define pcap_sendpacket f_pcap_sendpacket
+		#define pcap_close f_pcap_close
+		#define pcap_setnonblock f_pcap_setnonblock
+		#define pcap_setfilter f_pcap_setfilter
+		#define pcap_compile f_pcap_compile
+		#define pcap_geterr f_pcap_geterr
+		#define pcap_next_ex f_pcap_next_ex
+
+		#define PCAP_ERROR -1
+		#define PCAP_OPENFLAG_PROMISCUOUS 0x00000001
+		#define PCAP_OPENFLAG_NOCAPTURE_LOCAL 0x00000008
+#endif
 	printf("\n\n");
 	printf("   **======================================================================**\n");
 	printf("   ||                             ES40  emulator                           ||\n");

--- a/src/es40-cfg.cpp
+++ b/src/es40-cfg.cpp
@@ -69,6 +69,7 @@
 
 #if defined(HAVE_PCAP)
 #ifdef _WIN32
+#include <winsock.h>
 typedef int          bpf_int32;
 typedef unsigned int bpf_u_int32;
 

--- a/src/lockstep.cpp
+++ b/src/lockstep.cpp
@@ -46,12 +46,12 @@
 #include "lockstep.h"
 
 #if defined(IDB) && (defined(LS_MASTER) || defined(LS_SLAVE))
-int   ls_Socket;
+int64_t   ls_Socket;
 
 #if defined(LS_MASTER)
 char  ls_IP[30];
 #else
-int   ls_listenSocket;
+int64_t   ls_listenSocket;
 #endif
 void lockstep_init()
 {

--- a/src/lockstep.h
+++ b/src/lockstep.h
@@ -41,12 +41,12 @@
 #include "telnet.h"
 
 #if defined(IDB) && (defined(LS_MASTER) || defined(LS_SLAVE))
-extern int  ls_Socket;
+extern int64_t  ls_Socket;
 
 #if defined(LS_MASTER)
 extern char ls_IP[30];
 #else
-extern int  ls_listenSocket;
+extern int64_t  ls_listenSocket;
 #endif
 void        lockstep_init();
 void        lockstep_sync_m2s(const char* s);

--- a/src/telnet.h
+++ b/src/telnet.h
@@ -127,8 +127,11 @@
 
 #if defined(_WIN32) && defined(_MSC_VER)
 typedef size_t        ssize_t;
-typedef int           socklen_t;
 #endif // _WIN32
+
+#if defined(_WIN32)
+typedef int           socklen_t;
+#endif
 
 #if defined(__VMS)
 #define INVALID_SOCKET  - 1

--- a/src/telnet.h
+++ b/src/telnet.h
@@ -126,7 +126,6 @@
 #endif
 
 #if defined(_WIN32) && !defined(__GNUWIN32__)
-typedef size_t        ssize_t;
 typedef int           socklen_t;
 #endif // _WIN32
 

--- a/src/telnet.h
+++ b/src/telnet.h
@@ -125,7 +125,8 @@
 #include <signal.h>
 #endif
 
-#if defined(_WIN32) && !defined(__GNUWIN32__)
+#if defined(_WIN32) && defined(_MSC_VER)
+typedef size_t        ssize_t;
 typedef int           socklen_t;
 #endif // _WIN32
 


### PR DESCRIPTION
Switch PCap linking on Windows to be fully dynamic and optional (because of licensing problems of npcap) and fix ancient MinGWisms.