### PR TITLE
Define `_CRT_SECURE_NO_WARNINGS` to reduce log spams on Windows CI/CD builds

### DIFF
--- a/src/config_win32.h
+++ b/src/config_win32.h
@@ -333,6 +333,7 @@
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
 
 #define _CRT_SECURE_NO_DEPRECATE  1
+#define _CRT_SECURE_NO_WARNINGS 1
 
 #define WINVER  0x0502
 


### PR DESCRIPTION
As the title says.