### PR TITLE
Warning fixes

### DIFF
--- a/src/AliM1543C.cpp
+++ b/src/AliM1543C.cpp
@@ -2271,7 +2271,7 @@ int CAliM1543C::RestoreState(FILE* f)
  **/
 void CAliM1543C::lpt_reset()
 {
-	state.lpt_data = ~0;
+	state.lpt_data = '\xff';
 	state.lpt_status = 0xd8;  // busy, ack, online, error
 	state.lpt_control = 0x0c; // select, init
 	state.lpt_init = false;

--- a/src/AliM1543C_ide.cpp
+++ b/src/AliM1543C_ide.cpp
@@ -530,19 +530,19 @@ u32 CAliM1543C_ide::ReadMem_Legacy(int index, u32 address, int dsize)
 	{
 	case SEC_COMMAND:
 		channel = 1;
-
+		[[fallthrough]];
 	case PRI_COMMAND:
 		return ide_command_read(channel, address, dsize);
 
 	case SEC_CONTROL:
 		channel = 1;
-
+		[[fallthrough]];
 	case PRI_CONTROL:
 		return ide_control_read(channel, address);
 
 	case SEC_BUSMASTER:
 		channel = 1;
-
+		[[fallthrough]];
 	case PRI_BUSMASTER:
 		return ide_busmaster_read(channel, address, dsize);
 	}
@@ -557,14 +557,14 @@ void CAliM1543C_ide::WriteMem_Legacy(int index, u32 address, int dsize, u32 data
 	{
 	case SEC_COMMAND:
 		channel = 1;
-
+		[[fallthrough]];
 	case PRI_COMMAND:
 		ide_command_write(channel, address, dsize, data);
 		break;
 
 	case SEC_CONTROL:
 		channel = 1;
-
+		[[fallthrough]];
 	case PRI_CONTROL:
 		ide_control_write(channel, address, data);
 		break;
@@ -615,14 +615,14 @@ void CAliM1543C_ide::WriteMem_Bar(int func, int bar, u32 address, int dsize,
 	{
 	case BAR_SEC_COMMAND:
 		channel = 1;
-
+		[[fallthrough]];
 	case BAR_PRI_COMMAND:
 		ide_command_write(channel, address, dsize, data);
 		return;
 
 	case BAR_SEC_CONTROL:
 		channel = 1;
-
+		[[fallthrough]];
 	case BAR_PRI_CONTROL:
 		// we have to offset by two because the BAR starts at 3f4 vs 3f6
 		ide_control_write(channel, address - 2, data);

--- a/src/AlphaCPU.cpp
+++ b/src/AlphaCPU.cpp
@@ -734,7 +734,7 @@ void CAlphaCPU::check_state()
 void CAlphaCPU::execute()
 {
 	u32 ins;
-	int i;
+	int i = 0;
 	u64 phys_address;
 	u64 temp_64;
 	u64 temp_64_1;
@@ -923,14 +923,14 @@ void CAlphaCPU::execute()
 			if (state.check_timers)
 			{
 				state.check_timers = false;
-				for (int i = 0; i < 6; i++)
+				for (int j = 0; j < 6; j++)
 				{
-					if (state.irq_h_timer[i])
+					if (state.irq_h_timer[j])
 					{
-						if (state.irq_h_timer[i] <= 32)
+						if (state.irq_h_timer[j] <= 32)
 						{
-							state.irq_h_timer[i] = 0;
-							state.eir |= (U64(0x1) << i);
+							state.irq_h_timer[j] = 0;
+							state.eir |= (U64(0x1) << j);
 							// The timer hasn't reached 0 yet; check on the timers again next clock tick.
 							state.check_int = true;
 						}
@@ -938,7 +938,7 @@ void CAlphaCPU::execute()
 						{
 							// The timer has reached 0. Set the interrupt status, and set the flag that we
 							// need to check the interrupt status
-							state.irq_h_timer[i] -= 32;
+							state.irq_h_timer[j] -= 32;
 							state.check_timers = true;
 						}
 					}

--- a/src/Configurator.cpp
+++ b/src/Configurator.cpp
@@ -1018,6 +1018,10 @@ void CConfigurator::initialize()
 
 	case c_none:
 		break;
+
+	default:
+		FAILURE_1(Configuration, "Enum case not handled: %i", myClassId);
+		break;
 	}
 
 	for (i = 0; i < iNumChildren; i++)

--- a/src/Configurator.cpp
+++ b/src/Configurator.cpp
@@ -635,13 +635,13 @@ u64 CConfigurator::get_num_value(const char* n, bool decimal, u64 def)
 				{
 				case 'T':
 					partval *= multiplier;
-
+					[[fallthrough]];
 				case 'G':
 					partval *= multiplier;
-
+					[[fallthrough]];
 				case 'M':
 					partval *= multiplier;
-
+					[[fallthrough]];
 				case 'K':
 					retval += partval * multiplier;
 					partval = 0;

--- a/src/DEC21143.cpp
+++ b/src/DEC21143.cpp
@@ -437,7 +437,7 @@ static int (*f_pcap_set_snaplen)(void *, int);
 static int (*f_pcap_dispatch)(void *, int, pcap_handler callback, unsigned char *user);
 static void *(*f_pcap_create)(const char *, char *);
 static int (*f_pcap_activate)(void *);
-static void *(*f_pcap_geterr)(void *);
+static char *(*f_pcap_geterr)(void *);
 static pcap_t* (*f_pcap_open)(const char *source, int snaplen, int flags, int read_timeout, struct pcap_rmtauth *auth, char *errbuf);
 static int (*f_pcap_next_ex)(pcap_t *, struct pcap_pkthdr **, const unsigned char **);
 #endif
@@ -474,7 +474,7 @@ CDEC21143::CDEC21143(CConfigurator* confg, CSystem* c, int pcibus, int pcidev) :
 		f_pcap_set_snaplen = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_snaplen");
 		f_pcap_dispatch = (int (*)(void *, int, pcap_handler callback, unsigned char *user))GetProcAddress(libhandle, "pcap_dispatch");
 		f_pcap_create = (void * (*)(const char *, char *))GetProcAddress(libhandle, "pcap_create");
-		f_pcap_geterr = (void *(*)(void *))GetProcAddress(libhandle, "pcap_geterr");
+		f_pcap_geterr = (char *(*)(void *))GetProcAddress(libhandle, "pcap_geterr");
 		f_pcap_next_ex = (int (*)(pcap *, pcap_pkthdr **, const unsigned char **))GetProcAddress(libhandle, "pcap_next_ex");
 
 		#define pcap_findalldevs f_pcap_findalldevs
@@ -2288,7 +2288,7 @@ int CDEC21143::SaveState(FILE* f)
 	fwrite(&ss, sizeof(long), 1, f);
 	fwrite(&state, sizeof(state), 1, f);
 	fwrite(&nic_magic2, sizeof(u32), 1, f);
-	printf("%s: %d bytes saved.\n", devid_string, ss);
+	printf("%s: %li bytes saved.\n", devid_string, ss);
 	return 0;
 }
 
@@ -2352,7 +2352,7 @@ int CDEC21143::RestoreState(FILE* f)
 		return -1;
 	}
 
-	printf("%s: %d bytes restored.\n", devid_string, ss);
+	printf("%s: %li bytes restored.\n", devid_string, ss);
 	return 0;
 }
 

--- a/src/Disk.cpp
+++ b/src/Disk.cpp
@@ -1184,14 +1184,14 @@ int CDisk::do_scsi_command()
 				break;
 
 			case 0x80:
-				char serial_number[20];
-				sprintf(serial_number, "SRL%04x", scsi_initiator_id[0] * 0x0101);
+				char serial_number2[20];
+				sprintf(serial_number2, "SRL%04x", scsi_initiator_id[0] * 0x0101);
 
 				// unit serial number page
 				state.scsi.dati.data[1] = 0x80; // page code: 0x80
 				state.scsi.dati.data[2] = 0x00; // reserved
-				state.scsi.dati.data[3] = (u8)strlen(serial_number);
-				memcpy(&state.scsi.dati.data[4], serial_number, strlen(serial_number));
+				state.scsi.dati.data[3] = (u8)strlen(serial_number2);
+				memcpy(&state.scsi.dati.data[4], serial_number2, strlen(serial_number2));
 				break;
 
 			default:
@@ -2300,7 +2300,7 @@ int CDisk::do_scsi_command()
 		state.scsi.dati.available = retlen;
 		state.scsi.dati.read = 0;
 
-		int q = 2;
+		int q2 = 2;
 
 		/*Here's an actual response from a single-track pressed CD to the
 		  command  0x43, 00, 00, 00, 00, 00, 00, 00, 0x0c, 0x40, 00, 00
@@ -2310,57 +2310,57 @@ int CDisk::do_scsi_command()
 		  0020 01 00 00 00 00 00 00 00 01 00 00 00 01 00 01 00 ................
 		  0030 00 00 00 00 00 10 00 00 00 10 00 00 01 00 00 00 ................
 		*/
-		state.scsi.dati.data[q++] = 1;            // first track
-		state.scsi.dati.data[q++] = 1;            // last track
+		state.scsi.dati.data[q2++] = 1;            // first track
+		state.scsi.dati.data[q2++] = 1;            // last track
 		if (state.scsi.cmd.data[6] <= 1)
 		{
-			state.scsi.dati.data[q++] = 0;          // reserved
-			state.scsi.dati.data[q++] = 0x14;       // adr/control (Q-channel: current position, data track, no copy)
-			state.scsi.dati.data[q++] = 1;          // track number
-			state.scsi.dati.data[q++] = 0;          // reserved
+			state.scsi.dati.data[q2++] = 0;          // reserved
+			state.scsi.dati.data[q2++] = 0x14;       // adr/control (Q-channel: current position, data track, no copy)
+			state.scsi.dati.data[q2++] = 1;          // track number
+			state.scsi.dati.data[q2++] = 0;          // reserved
 			if (state.scsi.cmd.data[1] & 0x02)
 			{
 				u32 x = lba2msf(0);
-				state.scsi.dati.data[q++] = 0;
-				state.scsi.dati.data[q++] = (x & 0xff0000) >> 16;
-				state.scsi.dati.data[q++] = (x & 0xff00) >> 8;
-				state.scsi.dati.data[q++] = x & 0xff;
+				state.scsi.dati.data[q2++] = 0;
+				state.scsi.dati.data[q2++] = (x & 0xff0000) >> 16;
+				state.scsi.dati.data[q2++] = (x & 0xff00) >> 8;
+				state.scsi.dati.data[q2++] = x & 0xff;
 			}
 			else
 			{
-				state.scsi.dati.data[q++] = 0 >> 24;  //lba
-				state.scsi.dati.data[q++] = 0 >> 16;
-				state.scsi.dati.data[q++] = 0 >> 8;
-				state.scsi.dati.data[q++] = 0;
+				state.scsi.dati.data[q2++] = 0 >> 24;  //lba
+				state.scsi.dati.data[q2++] = 0 >> 16;
+				state.scsi.dati.data[q2++] = 0 >> 8;
+				state.scsi.dati.data[q2++] = 0;
 			}
 		}
 
-		state.scsi.dati.data[q++] = 0;            // reserved
-		state.scsi.dati.data[q++] = 0x16;         // adr/control (Q-channel: current position, data track, copy)
-		state.scsi.dati.data[q++] = 0xAA;         // track number
-		state.scsi.dati.data[q++] = 0;            // reserved
+		state.scsi.dati.data[q2++] = 0;            // reserved
+		state.scsi.dati.data[q2++] = 0x16;         // adr/control (Q-channel: current position, data track, copy)
+		state.scsi.dati.data[q2++] = 0xAA;         // track number
+		state.scsi.dati.data[q2++] = 0;            // reserved
 		if (state.scsi.cmd.data[1] & 0x02)
 		{
 			u32 x = lba2msf(get_lba_size());
-			state.scsi.dati.data[q++] = 0;
-			state.scsi.dati.data[q++] = (x & 0xff0000) >> 16;
-			state.scsi.dati.data[q++] = (x & 0xff00) >> 8;
-			state.scsi.dati.data[q++] = x & 0xff;
+			state.scsi.dati.data[q2++] = 0;
+			state.scsi.dati.data[q2++] = (x & 0xff0000) >> 16;
+			state.scsi.dati.data[q2++] = (x & 0xff00) >> 8;
+			state.scsi.dati.data[q2++] = x & 0xff;
 		}
 		else
 		{
-			state.scsi.dati.data[q++] = (u8)(get_lba_size() >> 24);  //lba
-			state.scsi.dati.data[q++] = (u8)(get_lba_size() >> 16);
-			state.scsi.dati.data[q++] = (u8)(get_lba_size() >> 8);
-			state.scsi.dati.data[q++] = (u8)get_lba_size();
+			state.scsi.dati.data[q2++] = (u8)(get_lba_size() >> 24);  //lba
+			state.scsi.dati.data[q2++] = (u8)(get_lba_size() >> 16);
+			state.scsi.dati.data[q2++] = (u8)(get_lba_size() >> 8);
+			state.scsi.dati.data[q2++] = (u8)get_lba_size();
 		}
 
-		state.scsi.dati.data[0] = (u8)(q >> 8);
-		state.scsi.dati.data[1] = (u8)q;
+		state.scsi.dati.data[0] = (u8)(q2 >> 8);
+		state.scsi.dati.data[1] = (u8)q2;
 
 #if defined(DEBUG_SCSI)
 		printf("%s: Returning data: ", devid_string);
-		for (unsigned int x1 = 0; x1 < q; x1++)
+		for (unsigned int x1 = 0; x1 < q2; x1++)
 			printf("%02x ", state.scsi.dati.data[x1]);
 		printf("\n");
 #endif

--- a/src/DiskDevice.cpp
+++ b/src/DiskDevice.cpp
@@ -206,8 +206,8 @@ size_t CDiskDevice::read_bytes(void* dest, size_t bytes)
 
 	if (r != (byte_len))
 	{
-		printf("%s: Tried to read %d bytes from pos %" PRId64
-			"d, but could only read %d bytes!\n", devid_string, byte_len,
+		printf("%s: Tried to read %lu bytes from pos %" PRId64
+			"d, but could only read %lu bytes!\n", devid_string, byte_len,
 			byte_from, r);
 		printf("%s: Error %ld.\n", devid_string, GetLastError());
 	}
@@ -257,8 +257,8 @@ size_t CDiskDevice::write_bytes(void* src, size_t bytes)
 		ReadFile(handle, buffer, (DWORD)dev_block_size, &r, NULL);
 		if (r != (dev_block_size))
 		{
-			printf("%s: Tried to read %d bytes from pos %" PRId64
-				"d, but could only read %zd bytes!\n", devid_string,
+			printf("%s: Tried to read %zu bytes from pos %" PRId64
+				"d, but could only read %lu bytes!\n", devid_string,
 				dev_block_size, byte_from, r);
 			FAILURE(InvalidArgument,
 				"Error during device write operation. Terminating to avoid disk corruption.");
@@ -276,8 +276,8 @@ size_t CDiskDevice::write_bytes(void* src, size_t bytes)
 			&r, NULL);
 		if (r != (dev_block_size))
 		{
-			printf("%s: Tried to read %d bytes from pos %" PRId64
-				"d, but could only read %zd bytes!\n", devid_string,
+			printf("%s: Tried to read %zu bytes from pos %" PRId64
+				"d, but could only read %lu bytes!\n", devid_string,
 				dev_block_size, byte_to - dev_block_size, r);
 			FAILURE(InvalidArgument,
 				"Error during device write operation. Terminating to avoid disk corruption.");
@@ -295,8 +295,8 @@ size_t CDiskDevice::write_bytes(void* src, size_t bytes)
 
 	if (r != byte_len)
 	{
-		printf("%s: Tried to write %d bytes to pos %" PRId64
-			"d, but could only write %d bytes!\n", devid_string, byte_len,
+		printf("%s: Tried to write %lu bytes to pos %" PRId64
+			"d, but could only write %lu bytes!\n", devid_string, byte_len,
 			byte_from, r);
 		FAILURE(InvalidArgument,
 			"Error during device write operation. Terminating to avoid disk corruption.");

--- a/src/DiskFile.cpp
+++ b/src/DiskFile.cpp
@@ -179,7 +179,7 @@ CDiskFile::~CDiskFile(void)
 	fclose(handle);
 }
 
-void CDiskFile::reload_file(char* filename)
+void CDiskFile::reload_file(char* _filename)
 {
 	if (handle)
 	{
@@ -187,12 +187,12 @@ void CDiskFile::reload_file(char* filename)
 		handle = nullptr;
 	}
 	if (read_only)
-		handle = fopen(filename, "rb");
+		handle = fopen(_filename, "rb");
 	else
-		handle = fopen_large(filename, "rb+");
+		handle = fopen_large(_filename, "rb+");
 	if (!handle)
 	{
-		printf("%s: Could not open file %s!\n", devid_string, filename);
+		printf("%s: Could not open file %s!\n", devid_string, _filename);
 
 		int sz = myCfg->get_num_value("autocreate_size", false, 0) / 1024 / 1024;
 		if (!sz)
@@ -200,7 +200,7 @@ void CDiskFile::reload_file(char* filename)
 				devid_string);
 
 		void* crt_buf;
-		handle = fopen_large(filename, "wb");
+		handle = fopen_large(_filename, "wb");
 		if (!handle)
 			FAILURE_1(Runtime, "%s: File does not exist and could not be created",
 				devid_string);
@@ -226,15 +226,15 @@ void CDiskFile::reload_file(char* filename)
 		fclose(handle);
 		free(crt_buf);
 		if (read_only)
-			handle = fopen_large(filename, "rb");
+			handle = fopen_large(_filename, "rb");
 		else
-			handle = fopen_large(filename, "rb+");
+			handle = fopen_large(_filename, "rb+");
 		if (!handle)
 		{
 			FAILURE_1(Runtime, "%s: File created could not be opened", devid_string);
 		}
 
-		printf("%s: %d MB file %s created.\n", devid_string, sz, filename);
+		printf("%s: %d MB file %s created.\n", devid_string, sz, _filename);
 	}
 
 	// determine size...

--- a/src/ES1370.cpp
+++ b/src/ES1370.cpp
@@ -103,42 +103,42 @@ CES1370::CES1370(CConfigurator* cfg, class CSystem* c, int pcibus, int pcidev) :
     as.freq = 44100;
     as.channels = 2;
     as.format = SDL_AUDIO_S16LE;
-	memset((void*)&s, 0, sizeof(s));
+	memset((void*)&state, 0, sizeof(state));
     if (!SDL_Init(SDL_INIT_AUDIO)) {
 		FAILURE_1(SDL, "Failed to initialize SDL audio: %s", SDL_GetError());
     }
-	s.audio_be_in = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_RECORDING, nullptr);
-    if (!s.audio_be_in) {
+	state.audio_be_in = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_RECORDING, nullptr);
+    if (!state.audio_be_in) {
         FAILURE_1(SDL, "Failed to initialize SDL audio input: %s", SDL_GetError());
     }
-    s.audio_be_out = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, nullptr);
-    if (!s.audio_be_out) {
+    state.audio_be_out = SDL_OpenAudioDevice(SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, nullptr);
+    if (!state.audio_be_out) {
         FAILURE_1(SDL, "Failed to initialize SDL audio output: %s", SDL_GetError());
     }
-    s.adc_voice = SDL_CreateAudioStream(NULL, &as);
-	s.dac_voice[0] = SDL_CreateAudioStream(&as, NULL);
-    s.dac_voice[1] = SDL_CreateAudioStream(&as, NULL);
+    state.adc_voice = SDL_CreateAudioStream(NULL, &as);
+	state.dac_voice[0] = SDL_CreateAudioStream(&as, NULL);
+    state.dac_voice[1] = SDL_CreateAudioStream(&as, NULL);
 
-	SDL_SetAudioStreamPutCallback(s.adc_voice, es1370_dac_callback_adc, this);
-    SDL_SetAudioStreamGetCallback(s.dac_voice[0], es1370_dac_callback_dac1, this);
-    SDL_SetAudioStreamGetCallback(s.dac_voice[1], es1370_dac_callback_dac2, this);
+	SDL_SetAudioStreamPutCallback(state.adc_voice, es1370_dac_callback_adc, this);
+    SDL_SetAudioStreamGetCallback(state.dac_voice[0], es1370_dac_callback_dac1, this);
+    SDL_SetAudioStreamGetCallback(state.dac_voice[1], es1370_dac_callback_dac2, this);
 }
 
 CES1370::~CES1370()
 {
-    SDL_DestroyAudioStream(s.adc_voice);
-    SDL_DestroyAudioStream(s.dac_voice[0]);
-    SDL_DestroyAudioStream(s.dac_voice[1]);
-    SDL_CloseAudioDevice(s.audio_be_in);
-    SDL_CloseAudioDevice(s.audio_be_out);
+    SDL_DestroyAudioStream(state.adc_voice);
+    SDL_DestroyAudioStream(state.dac_voice[0]);
+    SDL_DestroyAudioStream(state.dac_voice[1]);
+    SDL_CloseAudioDevice(state.audio_be_in);
+    SDL_CloseAudioDevice(state.audio_be_out);
 }
 
 void CES1370::init()
 {
     add_function(0, es_cfg_data, es_cfg_mask);
     ResetPCI();
-    es1370_reset(&s);
-    es1370_update_voices(&s, s.ctl, s.sctl);
+    es1370_reset(&state);
+    es1370_update_voices(&state, state.ctl, state.sctl);
 }
 
 void CES1370::es1370_update_status(ES1370State* s, uint32_t new_status)
@@ -442,11 +442,11 @@ u32 CES1370::ReadMem_Bar(int func, int bar, u32 address, int dsize)
         }
     }
     if (dsize == 32) {
-        return es1370_read(&s, address, dsize);
+        return es1370_read(&state, address, dsize);
     }
     if (dsize == 64) {
-        uint64_t low = es1370_read(&s, address, 32);
-        uint64_t high = es1370_read(&s, address + 4, 32);
+        uint64_t low = es1370_read(&state, address, 32);
+        uint64_t high = es1370_read(&state, address + 4, 32);
         return low | (high << 32);
 	}
     return ~0U;
@@ -481,7 +481,7 @@ void CES1370::WriteMem_Bar(int func, int bar, u32 address, int dsize, u32 data)
     }
 
 	if (dsize == 32) {
-        es1370_write(&s, address, data, dsize);
+        es1370_write(&state, address, data, dsize);
         return;
     }
 }
@@ -614,21 +614,21 @@ void CES1370::es1370_run_channel(ES1370State* s, size_t chan, int free_or_avail)
 void CES1370::es1370_dac_callback_dac1(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount)
 {
     CES1370* dev = (CES1370*)userdata;
-    ES1370State* s = &dev->s;
+    ES1370State* s = &dev->state;
     dev->es1370_run_channel(s, 0, additional_amount);
 }
 
 void CES1370::es1370_dac_callback_dac2(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount)
 {
     CES1370* dev = (CES1370*)userdata;
-    ES1370State* s = &dev->s;
+    ES1370State* s = &dev->state;
     dev->es1370_run_channel(s, 1, additional_amount);
 }
 
 void CES1370::es1370_dac_callback_adc(void* userdata, SDL_AudioStream* stream, int additional_amount, int total_amount)
 {
     CES1370* dev = (CES1370*)userdata;
-    ES1370State* s = &dev->s;
+    ES1370State* s = &dev->state;
     dev->es1370_run_channel(s, 2, additional_amount);
 }
 #endif /* HAVE_SDL */

--- a/src/ES1370.h
+++ b/src/ES1370.h
@@ -148,7 +148,7 @@ private:
     uint32_t mempage;
     uint32_t codec;
     uint32_t sctl;
-  } s;
+  } state;
 
   struct chan_bits {
     uint32_t ctl_en;

--- a/src/FloppyController.cpp
+++ b/src/FloppyController.cpp
@@ -335,7 +335,7 @@ void CFloppyController::WriteMem(int index, u64 address, int dsize, u64 data)
 					size_t count = (fdc_count < dma_count) ? fdc_count : dma_count;
 
 					printf("FDC [CMD %02x]: CHS=(%d/%d/%d) EOT=%d MT=%d. Drive=%d\n", cmd, cyl, head, sector, eot, mt, drive_idx);
-					printf("FDC [DMA]: Transfer size requested = %d bytes (%d sectors)\n", count, (int)(count/512));
+					printf("FDC [DMA]: Transfer size requested = %zu bytes (%zu sectors)\n", count, count/512);
 
 					u8* buffer = new u8[count];
 					memset(buffer, 0, count);
@@ -345,7 +345,7 @@ void CFloppyController::WriteMem(int index, u64 address, int dsize, u64 data)
 					SEL_FDISK->seek_byte((off_t_large)pos * 512);
 					if (cmd == 6) {
 						SEL_FDISK->read_bytes(buffer, count);
-						printf("FDC: read data:  %x @ %x\n  ", count, pos * 512);
+						printf("FDC: read data:  %zx @ %x\n  ", count, pos * 512);
 						for (int i = 0; i < count; i++)
 						{
 							printf("%02x ", *((char*)buffer + i) & 0xff);
@@ -356,7 +356,7 @@ void CFloppyController::WriteMem(int index, u64 address, int dsize, u64 data)
 						theDMA->send_data(2, buffer, count);
 					} else {
 						theDMA->recv_data(2, buffer, count);
-						printf("FDC: write data:  %x @ %x\n  ", count, pos * 512);
+						printf("FDC: write data:  %zx @ %x\n  ", count, pos * 512);
 						for (int i = 0; i < count; i++)
 						{
 							printf("%02x ", *((char*)buffer + i) & 0xff);

--- a/src/PCIDevice.cpp
+++ b/src/PCIDevice.cpp
@@ -691,13 +691,13 @@ void CPCIDevice::do_pci_read(u32 address, void* dest, size_t element_size,
 
 #if defined(ES40_BIG_ENDIAN)
 	}
-#endif
 
 	// outside main memory, or inside main memory with endian-conversion
 	// required we need to do the transfer element-by-element.
 	switch (element_size)
 	{
 	case 1:
+	{
 		for (el = 0; el < element_count; el++)
 		{
 			*(u8*)dst = (u8)cSystem->ReadMem(phys_addr, 8, this);
@@ -705,26 +705,29 @@ void CPCIDevice::do_pci_read(u32 address, void* dest, size_t element_size,
 			phys_addr++;
 		}
 		break;
+	}
 
 	case 2:
 	{
 		*(u16*)dst = endian_16((u16)cSystem->ReadMem(phys_addr, 16, this));
 		dst += 2;
 		phys_addr += 2;
+		break;
 	}
-	break;
 
 	case 4:
 	{
 		*(u32*)dst = endian_32((u32)cSystem->ReadMem(phys_addr, 32, this));
 		dst += 4;
 		phys_addr += 4;
+		break;
 	}
-	break;
 
 	default:
 		FAILURE(InvalidArgument, "Strange element size");
+		break;
 	}
+#endif
 }
 
 /**
@@ -801,13 +804,13 @@ void CPCIDevice::do_pci_write(u32 address, void* source, size_t element_size,
 
 #if defined(ES40_BIG_ENDIAN)
 	}
-#endif
 
 	// outside main memory, or inside main memory with endian-conversion
 	// required we need to do the transfer element-by-element.
 	switch (element_size)
 	{
 	case 1:
+	{
 		for (el = 0; el < element_count; el++)
 		{
 			cSystem->WriteMem(phys_addr, 8, *(u8*)src, this);
@@ -815,24 +818,28 @@ void CPCIDevice::do_pci_write(u32 address, void* source, size_t element_size,
 			phys_addr++;
 		}
 		break;
+	}
 
 	case 2:
 	{
 		cSystem->WriteMem(phys_addr, 16, endian_16(*(u16*)src), this);
 		src += 2;
 		phys_addr += 2;
+		break;
 	}
-	break;
 
 	case 4:
 	{
 		cSystem->WriteMem(phys_addr, 32, endian_32(*(u32*)src), this);
-		src += 4;;
+		src += 4;
 		phys_addr += 4;
+		break;
 	}
-	break;
 
 	default:
 		FAILURE(InvalidArgument, "Strange element size");
+		break;
 	}
+#endif
+}
 }

--- a/src/PCIDevice.cpp
+++ b/src/PCIDevice.cpp
@@ -842,4 +842,3 @@ void CPCIDevice::do_pci_write(u32 address, void* source, size_t element_size,
 	}
 #endif
 }
-}

--- a/src/S3Trio64.h
+++ b/src/S3Trio64.h
@@ -253,7 +253,7 @@ protected:
     case ATC_REG:  return m_atc_map;
     default:
       FAILURE_1(NotImplemented, "Unknown register space %d", spacenum);
-      return m_crtc_map; // unreachable
+      //return m_crtc_map; // unreachable
     }
   }
 

--- a/src/Serial.cpp
+++ b/src/Serial.cpp
@@ -783,13 +783,11 @@ void CSerial::serial_menu()
 		case '1':
 			write_cstr("%SRL-I-EXIT: exiting emulation gracefully.\r\n");
 			FAILURE(Graceful, "Graceful exit");
-			exitLoop = true;
 			break;
 
 		case '2':
 			write_cstr("%SRL-I-ABORT: aborting emulation.\r\n");
 			FAILURE(Abort, "Aborting");
-			exitLoop = true;
 			break;
 
 		case '3':
@@ -808,6 +806,7 @@ void CSerial::serial_menu()
 
 		default:
 			write_cstr("%SRL-W-INVALID: Not a valid answer.\r\n");
+			break;
 		}
 	}
 

--- a/src/Sym53C895.cpp
+++ b/src/Sym53C895.cpp
@@ -2117,7 +2117,7 @@ void CSym53C895::execute_rw_op()
 	bool  use_data8_sfbr = (GET_DBC() >> 23) & 1;
 	int   reg_address = ((GET_DBC() >> 16) & 0x7f); //| (GET_DBC() & 0x80); // manual is unclear about bit 7.
 	u8    imm_data = (u8)(GET_DBC() >> 8) & 0xff;
-	u8    op_data;
+	u8    op_data = 0;
 
 #if defined(DEBUG_SYM_SCRIPTS)
 	printf("SYM: INS = R/W (opc %d, oper %d, use %d, add %d, imm %02x\n",
@@ -2145,7 +2145,7 @@ void CSym53C895::execute_rw_op()
 		}
 	}
 
-	u16 tmp16;
+	u16 tmp16 = 0;
 
 	switch (oper)
 	{

--- a/src/VGA.cpp
+++ b/src/VGA.cpp
@@ -378,7 +378,7 @@ void CVGA::vga_vh_text(bitmap_rgb32& bitmap, const rectangle& cliprect)
 
 	int width = BIT(vga.sequencer.data[1], 0) ? 8 : 9, height = (vga.crtc.maximum_scan_line) * (vga.crtc.scan_doubling + 1);
 
-	const u32 frame_number = screen().frame_number();
+	const u32 frame_number = (u32)(screen().frame_number());
 
 	if (vga.crtc.cursor_enable)
 		vga.cursor.visible = frame_number & 0x10;
@@ -388,10 +388,12 @@ void CVGA::vga_vh_text(bitmap_rgb32& bitmap, const rectangle& cliprect)
 	bool blink_rate = frame_number & 0x20;
 	const int TEXT_LINES = vga.crtc.vert_disp_end + 1;
 
-	for (int addr = vga.crtc.start_addr, line = -vga.crtc.preset_row_scan; line < TEXT_LINES;
+	unsigned addr = 0;
+	int line = 0;
+	for (addr = vga.crtc.start_addr, line = -vga.crtc.preset_row_scan; line < TEXT_LINES;
 		line += height, addr += (offset() >> 1))
 	{
-		for (int pos = addr, column = 0; column < vga.crtc.horz_disp_end + 1; column++, pos++)
+		for (unsigned pos = addr, column = 0; column < vga.crtc.horz_disp_end + 1; column++, pos++)
 		{
 			const uint8_t ch = vga.memory[(pos << 1) + 0];
 			const uint8_t attr = vga.memory[(pos << 1) + 1];
@@ -755,20 +757,20 @@ void CVGA::svga_vh_rgb8(bitmap_rgb32& bitmap, const rectangle& cliprect)
 void CVGA::svga_vh_rgb15(bitmap_rgb32& bitmap, const rectangle& cliprect)
 {
 	constexpr uint32_t IV = 0xff000000;
-	const int height = vga.crtc.maximum_scan_line * (vga.crtc.scan_doubling + 1);
+	const unsigned height = vga.crtc.maximum_scan_line * (vga.crtc.scan_doubling + 1);
 
-	const int TLINES = (vga.crtc.vert_disp_end + 1) * (get_interlace_mode() + 1);
-	const int TGA_COLUMNS = vga.crtc.horz_disp_end + 1;
+	const unsigned TLINES = (vga.crtc.vert_disp_end + 1) * (get_interlace_mode() + 1);
+	const unsigned TGA_COLUMNS = vga.crtc.horz_disp_end + 1;
 	/* line compare is screen sensitive */
 //  uint16_t mask_comp = 0xff | (TLINES & 0x300);
 	int curr_addr = 0;
 	int yi = 0;
 
-	for (int addr = vga.crtc.start_addr << 2, line = 0; line < TLINES; line += height, addr += offset(), curr_addr += offset())
+	for (unsigned addr = vga.crtc.start_addr << 2, line = 0; line < TLINES; line += height, addr += offset(), curr_addr += offset())
 	{
 		uint32_t* const bitmapline = &bitmap.pix(line);
 		addr %= vga.svga_intf.vram_size;
-		for (int pos = addr, c = 0, column = 0; column < TGA_COLUMNS; column++, c += 8, pos += 0x10)
+		for (unsigned pos = addr, c = 0, column = 0; column < TGA_COLUMNS; column++, c += 8, pos += 0x10)
 		{
 			if (pos + 0x10 >= vga.svga_intf.vram_size)
 				return;
@@ -795,20 +797,20 @@ void CVGA::svga_vh_rgb15(bitmap_rgb32& bitmap, const rectangle& cliprect)
 void CVGA::svga_vh_rgb16(bitmap_rgb32& bitmap, const rectangle& cliprect)
 {
 	constexpr uint32_t IV = 0xff000000;
-	const int height = vga.crtc.maximum_scan_line * (vga.crtc.scan_doubling + 1);
-	const int TLINES = (vga.crtc.vert_disp_end + 1) * (get_interlace_mode() + 1);
-	const int TGA_COLUMNS = vga.crtc.horz_disp_end + 1;
+	const unsigned height = vga.crtc.maximum_scan_line * (vga.crtc.scan_doubling + 1);
+	const unsigned TLINES = (vga.crtc.vert_disp_end + 1) * (get_interlace_mode() + 1);
+	const unsigned TGA_COLUMNS = vga.crtc.horz_disp_end + 1;
 
 	/* line compare is screen sensitive */
 //  uint16_t mask_comp = 0xff | (TLINES & 0x300);
 	int curr_addr = 0;
 	int yi = 0;
 
-	for (int addr = vga.crtc.start_addr << 2, line = 0; line < TLINES; line += height, addr += offset(), curr_addr += offset())
+	for (unsigned addr = vga.crtc.start_addr << 2, line = 0; line < TLINES; line += height, addr += offset(), curr_addr += offset())
 	{
 		uint32_t* const bitmapline = &bitmap.pix(line);
 		addr %= vga.svga_intf.vram_size;
-		for (int pos = addr, c = 0, column = 0; column < TGA_COLUMNS; column++, c += 8, pos += 0x10)
+		for (unsigned pos = addr, c = 0, column = 0; column < TGA_COLUMNS; column++, c += 8, pos += 0x10)
 		{
 			if (pos + 0x10 >= vga.svga_intf.vram_size)
 				return;

--- a/src/cpu_debug.h
+++ b/src/cpu_debug.h
@@ -173,13 +173,16 @@ void          handle_debug_string(char* s);
     /* HRM 4.2.4: a taken exception/interrupt clears lock_flag so a pending  \
        STx_C fails. Exclude transparent TB-miss fills, which real HW does    \
        not use to clear the lock. */                            \
-    if((offset) != DTBM_SINGLE && (offset) != DTBM_DOUBLE_3 &&  \
-       (offset) != DTBM_DOUBLE_4 && (offset) != ITB_MISS)       \
+    if constexpr ((offset) != DTBM_SINGLE && (offset) != DTBM_DOUBLE_3 && \
+                  (offset) != DTBM_DOUBLE_4 && (offset) != ITB_MISS)      \
       cSystem->cpu_clear_lock(state.iProcNum);                  \
-    if((offset == DTBM_SINGLE || offset == ITB_MISS) && bTrace) \
-      trc->set_waitfor(this, state.exc_addr &~U64(0x3));        \
-    else                                                        \
-      TRC_(true, false, "GO_PAL %" PRIx64, offset);                 \
+    if constexpr ((offset) == DTBM_SINGLE || (offset) == ITB_MISS) { \
+      if(bTrace)                                               \
+        trc->set_waitfor(this, state.exc_addr &~U64(0x3));      \
+      else                                                      \
+        TRC_(true, false, "GO_PAL %" PRIx64, offset);           \
+    } else                                                      \
+      TRC_(true, false, "GO_PAL %" PRIx64, offset);             \
   }
 
 #else
@@ -194,8 +197,8 @@ void          handle_debug_string(char* s);
     /* HRM 4.2.4: clear lock_flag on taken exception/interrupt (fail a       \
        pending STx_C). Exclude transparent TB-miss fills; offset is a        \
        compile-time constant so this condition folds to nothing per site. */ \
-    if((offset) != DTBM_SINGLE && (offset) != DTBM_DOUBLE_3 &&               \
-       (offset) != DTBM_DOUBLE_4 && (offset) != ITB_MISS)                    \
+    if constexpr ((offset) != DTBM_SINGLE && (offset) != DTBM_DOUBLE_3 &&    \
+                  (offset) != DTBM_DOUBLE_4 && (offset) != ITB_MISS)         \
       cSystem->cpu_clear_lock(state.iProcNum);                               \
   }
 #endif

--- a/src/cpu_defs.h
+++ b/src/cpu_defs.h
@@ -521,7 +521,7 @@ inline u64 fsqrt64(u64 asig, s32 exp)
 #define DATA_PHYS_NT(addr, flags)                                               \
   {                                                                             \
     u64 _dpc_va = (addr);                                                       \
-    if (((flags) & ~ACCESS_WRITE) == 0) {                                       \
+    if constexpr (((flags) & ~ACCESS_WRITE) == 0) {                             \
       /* Normal read/write — try data page cache. The hit must match the      \
          current mode (cm) and data ASN (asn0): a hit bypasses virt2phys, so   \
          the per-mode protection check and ASN tag are only safe to skip when  \

--- a/src/cpu_pal.h
+++ b/src/cpu_pal.h
@@ -249,7 +249,7 @@
     case 0x0b:  /* IER_CM */                                                     \
       state.cm = (int) (state.r[REG_2] >> 3) & 3;                                \
       state.check_int = true;                                                    \
-                                                                            \
+      [[fallthrough]];                                                           \
     case 0x0a:  /* IER */                                                        \
       state.asten = (int) (state.r[REG_2] >> 13) & 1;                            \
       state.sien = (int) (state.r[REG_2] >> 13) & 0xfffe;                        \

--- a/src/es40-cfg.cpp
+++ b/src/es40-cfg.cpp
@@ -1070,7 +1070,7 @@ int main(int argc, char* argv[])
 		midi_q.addAnswer("list", "", "Get a list at run-time");
 		
 		MIDIOUTCAPSA caps;
-		for (int i = 0; i < midiOutGetNumDevs(); i++)
+		for (UINT i = 0; i < midiOutGetNumDevs(); i++)
 		{
 			midiOutGetDevCapsA(i, &caps, sizeof(caps));
 			midi_q.addAnswer(i2s(i + 1), i2s(i), string(caps.szPname));

--- a/src/gui/gui_win32.cpp
+++ b/src/gui/gui_win32.cpp
@@ -78,22 +78,22 @@ public:
 		bx_keymap = new bx_keymap_c(cfg);
 	};
 
-	virtual void  specific_init(unsigned x_tilesize, unsigned y_tilesize);
+	virtual void  specific_init(unsigned x_tilesize, unsigned y_tilesize) override;
 	virtual void  text_update(u8* old_text, u8* new_text,
 		unsigned long cursor_x, unsigned long cursor_y,
-		bx_vga_tminfo_t tm_info, unsigned rows);
-	virtual void  graphics_tile_update(u8* snapshot, unsigned x, unsigned y);
-	virtual void  handle_events(void);
-	virtual void  flush(void);
-	virtual void  clear_screen(void);
+		bx_vga_tminfo_t tm_info, unsigned rows) override;
+	virtual void  graphics_tile_update(u8* snapshot, unsigned x, unsigned y) override;
+	virtual void  handle_events(void) override;
+	virtual void  flush(void) override;
+	virtual void  clear_screen(void) override;
 	virtual bool  palette_change(unsigned index, unsigned red, unsigned green,
-		unsigned blue);
+		unsigned blue) override;
 	virtual void  dimension_update(unsigned x, unsigned y, unsigned fheight = 0,
-		unsigned fwidth = 0, unsigned bpp = 8);
-	virtual void  mouse_enabled_changed_specific(bool val);
-	virtual void  exit(void);
+		unsigned fwidth = 0, unsigned bpp = 8) override;
+	virtual void  mouse_enabled_changed_specific(bool val) override;
+	virtual void  exit(void) override;
 
-	virtual void  get_capabilities(u16* xres, u16* yres, u16* bpp);
+	virtual void  get_capabilities(u16* xres, u16* yres, u16* bpp) override;
 
 	virtual void  graphics_frame_update(const u32* pixels, unsigned width, unsigned height) override;
 private:
@@ -709,7 +709,8 @@ void resize_main_window()
 		SetWindowLong(stInfo.mainWnd, GWL_STYLE, mainStyle);
 
 		// maybe need to adjust stInfo.simWnd here also?
-		if (saveParent = SetParent(stInfo.mainWnd, desktopWindow))
+		saveParent = SetParent(stInfo.mainWnd, desktopWindow);
+		if (saveParent)
 		{
 			BX_DEBUG(("Saved parent window"));
 			SetWindowPos(stInfo.mainWnd, HWND_TOPMOST, desktop.left, desktop.top,
@@ -2034,8 +2035,8 @@ void bx_win32_gui_c::get_capabilities(u16* xres, u16* yres, u16* bpp)
 {
 	if (desktop_y > 0)
 	{
-		*xres = desktop_x;
-		*yres = desktop_y;
+		*xres = (u16)desktop_x;
+		*yres = (u16)desktop_y;
 		*bpp = 32;
 	}
 	else

--- a/src/gui/gui_win32.cpp
+++ b/src/gui/gui_win32.cpp
@@ -1159,7 +1159,8 @@ LRESULT CALLBACK simWndProc(HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
 				}
 			}
 		}
-
+		return 0;
+		
 	case WM_CHAR:
 	case WM_DEADCHAR:
 	case WM_SYSDEADCHAR:

--- a/src/logmacro.h
+++ b/src/logmacro.h
@@ -33,6 +33,6 @@ inline void logerror(const char* fmt, ...)
 #define LOG_GENERAL (1U << 0)
 #endif
 
-#define LOGMASKED(mask, ...) do { if (VERBOSE & (mask)) (LOG_OUTPUT_FUNC)(__VA_ARGS__); } while (false)
+#define LOGMASKED(mask, ...) do { if constexpr (VERBOSE & (mask)) (LOG_OUTPUT_FUNC)(__VA_ARGS__); } while (false)
 
 #define LOG(...) LOGMASKED(LOG_GENERAL, __VA_ARGS__)


### PR DESCRIPTION
Please review

You said you did not want to fix warnings yet, and this is certainly not fixes for all of them, however this should be a reviewable set. I did not fix warnings I wasn't sure about to leave for later.

AliM1543C.cpp:
`'\xff'` replacing `~0` satisfies implicit width conversion, since `~0` is an integer and `'\xff'` is a `char`.

AliM1543C_ide.cpp:
These fallthroughs are most certainly intentional, silence them.

AlphaCPU.cpp:
Redeclaration of `i` in that loop shadows the previously declared `i` that is later used in macros.

Configurator.cpp:
Fallthroughs are intentional logic.
Fail on default case.

Disk.cpp:
`serial_number` is redeclared in this local block and shadows member variable of same name in `CDisk`. Just rename it locally.
`q` shadows an earlier declaration as well, seems safe to rename local use of it since it was already shadowing.

DiskDevice.cpp:
Fix `printf` format correctness

DiskFile.cpp:
Fix shadowed member variable warnings.

DEC21143.cpp:
Fix function pointer conversion warnings and `printf` formatting issues.

ES1370.cpp/ES1370.h:
`s` shadows in a lot of instances in this code, easiest fix was renaming the member variable from `s` to `state` and moving usages of that than renaming `s` argument to solve the shadowing.

FloppyController.cpp:
Fix printf formatting issues

PCIDevice.cpp:
Fix unreachable code warnings as a result of unconditional `return` existing due to preprocessor macros. Fix is moving `#endif` down to encapsulate it. It never ran in this case (unreachable), so don't compile it. Also fix some of the code structure.

S3Trio64.h:
Fix unreachable code warning.

Serial.cpp:
Fix unreachable code warnings.

Sym53C895.cpp:
Initialize the uninitialized.

VGA.cpp:
Fix a number of sign conversion issues

cpu_debug.h/cpu_defs.h:
Expression in if statement is const and always evaluates to true, so mark it `constexpr`. Fixes MSVC warnings.

cpu_pal.h:
Fix fallthrough warning. I read 21264 documentation and it seems intentional.

gui_win32.cpp:
Fix functions not being marked `override`, and unintended fallthrough.

