### PR TITLE
SDL: swap CD disks for files

### DIFF
--- a/src/DiskFile.cpp
+++ b/src/DiskFile.cpp
@@ -131,6 +131,35 @@ void win32_select_file(HWND hwnd)
 		}
 	}
 }
+#elif defined(HAVE_SDL)
+#include <SDL3/SDL.h>
+
+static const SDL_DialogFileFilter filters[] = {
+	{ "ISO files",  "iso" },
+	{ "All files",   "*" }
+};
+
+static void SDLCALL callback(void* userdata, const char* const* filelist, int filter)
+{
+	if (!filelist) {
+		SDL_Log("An error occured: %s", SDL_GetError());
+		return;
+	} else if (!*filelist) {
+		SDL_Log("The user did not select any file.");
+		return;
+	}
+
+	if (cd_diskfiles.size() > 0) {
+		char* szFileName = SDL_strdup(filelist[0]);
+		SDL_Log("Change ISO file to %s", szFileName);
+		cd_diskfiles[0]->reload_file(szFileName);
+		SDL_free(szFileName);
+	}
+}
+
+void sdl_select_file(SDL_Window* window) {
+	SDL_ShowOpenFileDialog(callback, nullptr, window, filters, SDL_arraysize(filters), nullptr, false);
+}
 #endif
 
 CDiskFile::CDiskFile(CConfigurator* cfg, CSystem* sys, CDiskController* c,

--- a/src/gui/sdl.cpp
+++ b/src/gui/sdl.cpp
@@ -504,6 +504,9 @@ void bx_sdl_gui_c::handle_events(void)
 			}
 #ifdef _WIN32
 			extern void win32_select_file(HWND hwnd);
+#else
+			extern void sdl_select_file(SDL_Window*);
+#endif
 			if (sdl_event.key.key == SDLK_F11 && (sdl_event.key.mod & SDL_KMOD_CTRL))
 			{
 				theKeyboard->gen_scancode(BX_KEY_CTRL_L | BX_KEY_RELEASED);
@@ -512,12 +515,15 @@ void bx_sdl_gui_c::handle_events(void)
 				if (sdl_grab)
 					bx_gui->mouse_enabled_changed(false);
 
+#ifdef _WIN32
 				win32_select_file((HWND)SDL_GetPointerProperty(SDL_GetWindowProperties(sdl_window), SDL_PROP_WINDOW_WIN32_HWND_POINTER, nullptr));
+#else
+				sdl_select_file(sdl_window);
+#endif
 
 				sdl_swallow_keys = true;  // eat subsequent releases
 				break;
 			}
-#endif
 			if (sdl_swallow_keys)
 				break;  // swallow any key-down during toggle
 


### PR DESCRIPTION
Since SDL3 there's SDL_ShowOpenFileDialog(), another code path could be add

_... although there're lots of edge cases, e.g._
1. it depends on XDG or zenity at runtime, so setups with simple wm on X won't work `File dialog driver unsupported`
3. one of my box won't work with the default `portal` driver (`arguments to dbus_message_unref() were incorrect`) and I had to specify `SDL_FILE_DIALOG_DRIVER=zenity`
4. won't work with remote X (which is common dev env with WSL2)
5. I had to retry once when changing media, but this seems same as win32 version:
(in Disk.cpp)when querying SCSICMD_TEST_UNIT_READY
state.scsi.media_changed == 1  =>  SCSI_MEDIA_REMOVED; state.scsi.media_changed = -1
state.scsi.media_changed == -1  =>  SCSI_MEDIA_CHANGE