### PR TITLE
SDL: swap CD file selector fix

### DIFF
--- a/src/DiskFile.cpp
+++ b/src/DiskFile.cpp
@@ -167,6 +167,9 @@ static void SDLCALL callback(void* userdata, const char* const* filelist,
     {
         SDL_Log("The user did not select any file.");
         return;
+    } else if (!**filelist) {
+        SDL_Log("The user selected an empty file.");
+        return;
     }
 
     if (cd_diskfiles.size() > 0)


### PR DESCRIPTION
A small fix for swap CD file selector dialog
When SDL invoke zenity (the file selector dialog) and the user canceled, an empty string (with null terminator at pointer) is returned.
zenity though, is preferred than default SDL dialog driver _portal_ when using remote X.

Actually I have a patch locally (as this is somehow dirty to upstream):
```patch
diff --git a/src/DiskFile.cpp b/src/DiskFile.cpp
index 486070b..70cc676 100644
--- a/src/DiskFile.cpp
+++ b/src/DiskFile.cpp
@@ -183,6 +183,11 @@ static void SDLCALL callback(void* userdata, const char* const* filelist,

 void sdl_select_file(SDL_Window* window)
 {
+    const char* sshcon = getenv("SSH_CONNECTION");
+    const char* sshclt = getenv("SSH_CLIENT");
+    if (sshcon || sshclt) {
+        SDL_SetHint(SDL_HINT_FILE_DIALOG_DRIVER, "zenity");
+    }
     SDL_ShowOpenFileDialog(callback, nullptr, window, filters,
                            SDL_arraysize(filters), nullptr, false);
 }
```
But SDL will fail (instead trying portal) if zenity is not available, et non vice versa (SDL by default will try portal then zenity), something maybe like:
```
command -v zenity >/dev/null 2>&1 && export SDL_HINT_FILE_DIALOG_DRIVER=zenity
```
