### PR TITLE
Idle host CPU: complete CALL_PAL WTINT (0x3E) natively so guests can actually sleep

### DIFF
--- a/src/AlphaCPU.cpp
+++ b/src/AlphaCPU.cpp
@@ -427,35 +427,22 @@ void CAlphaCPU::run()
 }
 
 /**
- * Host-side idle nap: sleep this CPU's host thread until an interrupt may be
- * deliverable, instead of spinning while the guest is idle.
- *
- * Caller: CALL_PAL WTINT (0x3E).  The guest's idle loop (Tru64's idle thread,
- * or OpenVMS with the SRI idle driver) issues WTINT -- "wait for interrupt".
- * Under VMS PALcode this is completed natively (vmspal_call_wtint(): nap
- * here, R0=0, no ROM vector -- the ROM has no 0x3e handler and would
- * OPCDEC).  Under OSF PALcode the ROM implements WTINT, so DO_CALL_PAL
- * naps here first and then vectors to the ROM unchanged.
- *
- * Nothing guest-visible is altered: wall-clock time passes during the nap
- * exactly as on real silicon (RPCC and the interval timer are both
- * wall-clock-paced, and jit_run() fires any due tick as soon as the nap ends).
- *
- * Wake conditions:
- *  - state.check_int / state.check_timers -- raised cross-thread by irq_h()
- *    for immediate and delayed interrupt assertion respectively.  Polled at
- *    100us granularity, which bounds added interrupt latency at ~one poll
- *    step (vs. the guest's own multi-ms interval-timer period).
- *  - CPU0 only: next_timer_fire.  CPU0's own dispatch loop drives the
- *    wall-clock Cchip interval timer, so it must never sleep past the next
- *    scheduled fire -- no other thread would fire the tick.
- *  - StopThread / system reset, so shutdown never blocks on an idle guest.
- *  - The nap is capped at 1ms so the CPU stays responsive to state it does
- *    not poll here (e.g. wait_for_start reset interactions).
+ * CALL_PAL WTINT: sleep the host thread while the guest idles, instead of
+ * spinning.  Guest-visible time is unaffected -- RPCC and the interval timer
+ * are wall-clock-paced.  Wakes when an interrupt/timer is pending (polled at
+ * 100us) or on StopThread/reset, and is capped at 1ms; CPU0 additionally
+ * never sleeps past next_timer_fire, because its own dispatch loop is what
+ * fires the interval tick.  No-op unless the cpu config sets idle_nap = true,
+ * and on multiprocessor configs regardless (waking a napping sibling CPU
+ * needs cross-thread IPI wakeup this change does not attempt; WTINT still
+ * completes correctly, it just returns immediately).
  **/
 void CAlphaCPU::idle_nap()
 {
 	using namespace std::chrono;
+
+	if (!idle_nap_enabled || (cSystem && cSystem->get_cpu_num() > 1))
+		return;
 
 	if (!idle_announced)
 	{
@@ -496,6 +483,7 @@ void CAlphaCPU::init()
 	last_dtb_virt[0] = last_dtb_virt[1] = 0;
 
 	cpu_hz = myCfg->get_num_value("speed", true, 500000000);
+	idle_nap_enabled = myCfg->get_bool_value("idle_nap", false);
 #ifdef ES40_JIT
 	// With the JIT, PALcode runs natively (compiled like any other guest code) rather than being
 	// shortcut by the high-level vmspal routines, so the replacement is force-disabled
@@ -604,6 +592,7 @@ void CAlphaCPU::ResetForSystemReset()
 	state.iProcNum = savedProcNum;
 
 	cpu_hz = myCfg->get_num_value("speed", true, 500000000);
+	idle_nap_enabled = myCfg->get_bool_value("idle_nap", false);
 
 	state.wait_for_start = (state.iProcNum == 0) ? false : true;
 	icache_enabled = true;

--- a/src/AlphaCPU.cpp
+++ b/src/AlphaCPU.cpp
@@ -427,9 +427,20 @@ void CAlphaCPU::run()
 }
 
 /**
- * CALL_PAL WTINT: sleep the host thread while the guest idles.  Wakes on
- * pending interrupt/timer, StopThread, or reset (100us poll, 1ms cap); CPU0
- * never sleeps past next_timer_fire, since its own loop fires the interval
+ * idle_nap: sleep the cpu thread while the guest idles.  
+ * HIGHLY EXPERIMENTAL
+ * Should be mostly-safe on Linux, but still can oversleep in various edge cases.
+ * Cchip timer is only checked before entering JIT loop, same with interpreter. 
+ * so 'never sleeps past next_timer_fire' below is not guaranteed on any platform.
+ * Various other guest-configurable aspects can also change these timelines
+ * IPIs could be delayed in response from CPU0. This may or may not trigger
+ * guest timeouts
+ * FreeBSD is probably the safest host platform this code can run on. 
+ * CPU0 DOES NOT IMMEDIATELY SERIVCE THE TIMER AFTER THE NAP
+ *
+ * Intended operation of this function: 
+ * Wakes on pending interrupt/timer, StopThread, or reset (100us poll, 1ms cap); 
+ * CPU0 never sleeps past next_timer_fire, since its own loop fires the interval
  * tick.  No-op unless idle_nap = true in the cpu config, and on MP configs
  * (no cross-thread IPI wakeup here -- WTINT just returns immediately).
  **/
@@ -447,6 +458,7 @@ void CAlphaCPU::idle_nap()
 		fflush(stdout);   // stdout is block-buffered when captured by a service manager
 	}
 
+	
 	auto deadline = steady_clock::now() + milliseconds(1);
 	if (state.iProcNum == 0 && next_timer_fire < deadline)
 		deadline = next_timer_fire;

--- a/src/AlphaCPU.cpp
+++ b/src/AlphaCPU.cpp
@@ -427,15 +427,11 @@ void CAlphaCPU::run()
 }
 
 /**
- * CALL_PAL WTINT: sleep the host thread while the guest idles, instead of
- * spinning.  Guest-visible time is unaffected -- RPCC and the interval timer
- * are wall-clock-paced.  Wakes when an interrupt/timer is pending (polled at
- * 100us) or on StopThread/reset, and is capped at 1ms; CPU0 additionally
- * never sleeps past next_timer_fire, because its own dispatch loop is what
- * fires the interval tick.  No-op unless the cpu config sets idle_nap = true,
- * and on multiprocessor configs regardless (waking a napping sibling CPU
- * needs cross-thread IPI wakeup this change does not attempt; WTINT still
- * completes correctly, it just returns immediately).
+ * CALL_PAL WTINT: sleep the host thread while the guest idles.  Wakes on
+ * pending interrupt/timer, StopThread, or reset (100us poll, 1ms cap); CPU0
+ * never sleeps past next_timer_fire, since its own loop fires the interval
+ * tick.  No-op unless idle_nap = true in the cpu config, and on MP configs
+ * (no cross-thread IPI wakeup here -- WTINT just returns immediately).
  **/
 void CAlphaCPU::idle_nap()
 {

--- a/src/AlphaCPU.cpp
+++ b/src/AlphaCPU.cpp
@@ -356,6 +356,7 @@
 #if defined(_M_X64) || defined(__x86_64__)
 #include <xmmintrin.h>   // _mm_setcsr: pin host MXCSR for the JIT SSE FP path
 #endif
+#include <thread>        // std::this_thread::sleep_for (idle_nap)
 
 void CAlphaCPU::release_threads()
 {
@@ -422,6 +423,61 @@ void CAlphaCPU::run()
 		printf("Exception in CPU thread: %s.\n", e.displayText().c_str());
 
 		// Let the thread die...
+	}
+}
+
+/**
+ * Host-side idle nap: sleep this CPU's host thread until an interrupt may be
+ * deliverable, instead of spinning while the guest is idle.
+ *
+ * Caller: CALL_PAL WTINT (0x3E).  The guest's idle loop (Tru64's idle thread,
+ * or OpenVMS with the SRI idle driver) issues WTINT -- "wait for interrupt".
+ * Under VMS PALcode this is completed natively (vmspal_call_wtint(): nap
+ * here, R0=0, no ROM vector -- the ROM has no 0x3e handler and would
+ * OPCDEC).  Under OSF PALcode the ROM implements WTINT, so DO_CALL_PAL
+ * naps here first and then vectors to the ROM unchanged.
+ *
+ * Nothing guest-visible is altered: wall-clock time passes during the nap
+ * exactly as on real silicon (RPCC and the interval timer are both
+ * wall-clock-paced, and jit_run() fires any due tick as soon as the nap ends).
+ *
+ * Wake conditions:
+ *  - state.check_int / state.check_timers -- raised cross-thread by irq_h()
+ *    for immediate and delayed interrupt assertion respectively.  Polled at
+ *    100us granularity, which bounds added interrupt latency at ~one poll
+ *    step (vs. the guest's own multi-ms interval-timer period).
+ *  - CPU0 only: next_timer_fire.  CPU0's own dispatch loop drives the
+ *    wall-clock Cchip interval timer, so it must never sleep past the next
+ *    scheduled fire -- no other thread would fire the tick.
+ *  - StopThread / system reset, so shutdown never blocks on an idle guest.
+ *  - The nap is capped at 1ms so the CPU stays responsive to state it does
+ *    not poll here (e.g. wait_for_start reset interactions).
+ **/
+void CAlphaCPU::idle_nap()
+{
+	using namespace std::chrono;
+
+	if (!idle_announced)
+	{
+		idle_announced = true;
+		printf("*** CPU%d *** idle nap engaged ***\n", get_cpuid());
+		fflush(stdout);   // stdout is block-buffered when captured by a service manager
+	}
+
+	auto deadline = steady_clock::now() + milliseconds(1);
+	if (state.iProcNum == 0 && next_timer_fire < deadline)
+		deadline = next_timer_fire;
+
+	while (!state.check_int && !state.check_timers && !StopThread
+		   && !(cSystem && cSystem->IsSystemResetRequested()))
+	{
+		const auto now = steady_clock::now();
+		if (now >= deadline)
+			break;
+		auto nap = deadline - now;
+		if (nap > microseconds(100))
+			nap = microseconds(100);
+		std::this_thread::sleep_for(nap);
 	}
 }
 

--- a/src/AlphaCPU.h
+++ b/src/AlphaCPU.h
@@ -398,6 +398,7 @@ private:
   void            vmspal_call_mfpr_astsr();
   void            vmspal_call_mfpr_vptb();
   void            vmspal_call_mtpr_datfx();
+  void            vmspal_call_wtint();
   void            vmspal_call_mfpr_whami();
   void            vmspal_call_imb();
   void            vmspal_call_prober();
@@ -449,6 +450,13 @@ private:
   // catch-up so backlog repays at no more than 2x the nominal rate.
   std::chrono::steady_clock::time_point next_timer_fire;
   std::chrono::steady_clock::time_point tick_last_fire;
+
+  // WTINT instrumentation. wtint_count totals every natively-completed
+  // CALL_PAL WTINT; the first few are logged with their PC so a load-time
+  // probe (one-shot, image-space PC) is distinguishable from the runtime
+  // idle callout (repeating, S0-space PC).
+  u64                                   wtint_count = 0;
+  int                                   wtint_logged = 0;
 
   // Wall-clock RPCC: state.cc advances by real elapsed time * cpu_hz so it tracks the configured
   // CPU frequency regardless of how fast/bursty the JIT runs. This is the last sync timestamp;

--- a/src/AlphaCPU.h
+++ b/src/AlphaCPU.h
@@ -257,6 +257,7 @@ public:
   virtual int   SaveState(FILE* f);
   virtual int   RestoreState(FILE* f);
   void          irq_h(int number, bool assert, int delay);
+  void          idle_nap();
   int           get_cpuid();
   void          flush_icache();
 
@@ -450,6 +451,9 @@ private:
   // catch-up so backlog repays at no more than 2x the nominal rate.
   std::chrono::steady_clock::time_point next_timer_fire;
   std::chrono::steady_clock::time_point tick_last_fire;
+
+  // One-shot announcement that this CPU's idle loop reached idle_nap().
+  bool                                  idle_announced = false;
 
   // WTINT instrumentation. wtint_count totals every natively-completed
   // CALL_PAL WTINT; the first few are logged with their PC so a load-time

--- a/src/AlphaCPU.h
+++ b/src/AlphaCPU.h
@@ -452,15 +452,10 @@ private:
   std::chrono::steady_clock::time_point next_timer_fire;
   std::chrono::steady_clock::time_point tick_last_fire;
 
-  // One-shot announcement that this CPU's idle loop reached idle_nap().
+  // CALL_PAL WTINT idle handling: off unless the cpu config sets
+  // idle_nap = true.  idle_announced makes the first nap log once.
+  bool                                  idle_nap_enabled = false;
   bool                                  idle_announced = false;
-
-  // WTINT instrumentation. wtint_count totals every natively-completed
-  // CALL_PAL WTINT; the first few are logged with their PC so a load-time
-  // probe (one-shot, image-space PC) is distinguishable from the runtime
-  // idle callout (repeating, S0-space PC).
-  u64                                   wtint_count = 0;
-  int                                   wtint_logged = 0;
 
   // Wall-clock RPCC: state.cc advances by real elapsed time * cpu_hz so it tracks the configured
   // CPU frequency regardless of how fast/bursty the JIT runs. This is the last sync timestamp;

--- a/src/AlphaCPU.h
+++ b/src/AlphaCPU.h
@@ -452,8 +452,7 @@ private:
   std::chrono::steady_clock::time_point next_timer_fire;
   std::chrono::steady_clock::time_point tick_last_fire;
 
-  // CALL_PAL WTINT idle handling: off unless the cpu config sets
-  // idle_nap = true.  idle_announced makes the first nap log once.
+  // CALL_PAL WTINT idle nap: enabled by the cpu config, announced once
   bool                                  idle_nap_enabled = false;
   bool                                  idle_announced = false;
 

--- a/src/AlphaCPU_vmspal.cpp
+++ b/src/AlphaCPU_vmspal.cpp
@@ -651,48 +651,16 @@ void CAlphaCPU::vmspal_call_mtpr_datfx()
 /**
  * Implementation of CALL_PAL WTINT opcode (function 0x3E, "wait for interrupt").
  *
- * The ES40 SRM ROM's VMS PALcode has no handler for 0x3E: vectoring there
- * raises OPCDEC in the guest -- which is exactly what the SRI/CHARON SYS$IDLE
- * driver's load-time probe tests for (it executes WTINT under a condition
- * handler and returns SS$_UNSUPPORTED on the fault).  So WTINT must be
- * completed natively like the other vmspal_call_* functions, never delegated
- * to the ROM.
- *
- * Semantics (Alpha ARM, VMS/OSF common PAL): stall the CPU until an interrupt
- * may be deliverable, then return in R0 the number of interval-clock ticks
- * skipped while stalled.  idle_nap() sleeps the host thread but -- on CPU 0,
- * which drives the wall-clock Cchip interval tick -- never past
- * next_timer_fire, and the tick schedule is count-preserving with catch-up.
- * No tick is ever skipped, so R0 = 0 is the true answer, not just the
- * architecturally-permitted minimum.
- *
- * Privilege: the caller-mode check lives in DO_CALL_PAL (function < 0x40 with
- * state.cm != 0 traps OPCDEC before dispatch reaches this helper), same as
- * every other privileged PAL function.  PC: the interpreter advanced state.pc
- * past the CALL_PAL before decode, so like the other direct completions this
- * helper must not touch it.  Interrupt dispatch: the interpreter's step top
- * and jit_run's dispatch gates both refuse compiled code while
- * check_int/check_timers is pending, so an interrupt arriving during the nap
- * is serviced before any further guest code runs.
+ * The SRM ROM's VMS PALcode has no 0x3E handler, so vectoring there raises
+ * OPCDEC in the guest -- the exact fault the SRI/CHARON SYS$IDLE driver
+ * probes for at load time.  Completing it natively is what lets that driver
+ * load, and with it the guest idle.  R0 (ticks skipped while stalled) is 0
+ * truthfully: idle_nap() never sleeps CPU0 past next_timer_fire and the tick
+ * schedule is count-preserving, so no tick is ever skipped.  PC was already
+ * advanced past the CALL_PAL; leave it alone.
  **/
 void CAlphaCPU::vmspal_call_wtint()
 {
-	wtint_count++;
-	if (wtint_logged < 8)
-	{
-		wtint_logged++;
-		printf("*** CPU%d *** WTINT #%llu at pc=%016llx (native completion) ***\n",
-			   get_cpuid(), (unsigned long long) wtint_count,
-			   (unsigned long long) state.current_pc);
-		fflush(stdout);   // stdout is block-buffered under a service manager
-	}
-	else if ((wtint_count & 0xfffff) == 0)   // liveness marker every 2^20 calls
-	{
-		printf("*** CPU%d *** WTINT count %llu ***\n", get_cpuid(),
-			   (unsigned long long) wtint_count);
-		fflush(stdout);
-	}
-
 	idle_nap();
 	r0 = 0;
 }

--- a/src/AlphaCPU_vmspal.cpp
+++ b/src/AlphaCPU_vmspal.cpp
@@ -649,15 +649,10 @@ void CAlphaCPU::vmspal_call_mtpr_datfx()
 }
 
 /**
- * Implementation of CALL_PAL WTINT opcode (function 0x3E, "wait for interrupt").
- *
- * The SRM ROM's VMS PALcode has no 0x3E handler, so vectoring there raises
- * OPCDEC in the guest -- the exact fault the SRI/CHARON SYS$IDLE driver
- * probes for at load time.  Completing it natively is what lets that driver
- * load, and with it the guest idle.  R0 (ticks skipped while stalled) is 0
- * truthfully: idle_nap() never sleeps CPU0 past next_timer_fire and the tick
- * schedule is count-preserving, so no tick is ever skipped.  PC was already
- * advanced past the CALL_PAL; leave it alone.
+ * CALL_PAL WTINT (0x3E): the SRM ROM's VMS PALcode has no 0x3E handler and
+ * OPCDECs -- the exact fault the SRI SYS$IDLE driver probes for -- so
+ * complete it natively.  R0 = 0 is truthful: the tick schedule is
+ * count-preserving, no tick is skipped during the nap.  PC already advanced.
  **/
 void CAlphaCPU::vmspal_call_wtint()
 {

--- a/src/AlphaCPU_vmspal.cpp
+++ b/src/AlphaCPU_vmspal.cpp
@@ -649,6 +649,49 @@ void CAlphaCPU::vmspal_call_mtpr_datfx()
 }
 
 /**
+ * Implementation of CALL_PAL WTINT opcode (function 0x3E, "wait for interrupt").
+ *
+ * The ES40 SRM ROM's VMS PALcode has no handler for 0x3E: vectoring there
+ * raises OPCDEC in the guest -- which is exactly what the SRI/CHARON SYS$IDLE
+ * driver's load-time probe tests for (it executes WTINT under a condition
+ * handler and returns SS$_UNSUPPORTED on the fault).  So WTINT must be
+ * completed natively like the other vmspal_call_* functions, never delegated
+ * to the ROM.
+ *
+ * Semantics (Alpha ARM, VMS/OSF common PAL): stall the CPU until an interrupt
+ * may be deliverable, then return in R0 the number of interval-clock ticks
+ * skipped while stalled.  This completes immediate-return: returning without
+ * a stall is architecturally valid (zero ticks skipped, R0 = 0).  The actual
+ * host-thread idle sleep is added on top of this in a separate change.
+ *
+ * Privilege: the caller-mode check lives in DO_CALL_PAL (function < 0x40 with
+ * state.cm != 0 traps OPCDEC before dispatch reaches this helper), same as
+ * every other privileged PAL function.  PC: the interpreter advanced state.pc
+ * past the CALL_PAL before decode, so like the other direct completions this
+ * helper must not touch it.
+ **/
+void CAlphaCPU::vmspal_call_wtint()
+{
+	wtint_count++;
+	if (wtint_logged < 8)
+	{
+		wtint_logged++;
+		printf("*** CPU%d *** WTINT #%llu at pc=%016llx (native completion) ***\n",
+			   get_cpuid(), (unsigned long long) wtint_count,
+			   (unsigned long long) state.current_pc);
+		fflush(stdout);   // stdout is block-buffered under a service manager
+	}
+	else if ((wtint_count & 0xfffff) == 0)   // liveness marker every 2^20 calls
+	{
+		printf("*** CPU%d *** WTINT count %llu ***\n", get_cpuid(),
+			   (unsigned long long) wtint_count);
+		fflush(stdout);
+	}
+
+	r0 = 0;
+}
+
+/**
  * Implementation of CALL_PAL MFPR_WHAMI opcode.
  **/
 void CAlphaCPU::vmspal_call_mfpr_whami()

--- a/src/AlphaCPU_vmspal.cpp
+++ b/src/AlphaCPU_vmspal.cpp
@@ -660,15 +660,20 @@ void CAlphaCPU::vmspal_call_mtpr_datfx()
  *
  * Semantics (Alpha ARM, VMS/OSF common PAL): stall the CPU until an interrupt
  * may be deliverable, then return in R0 the number of interval-clock ticks
- * skipped while stalled.  This completes immediate-return: returning without
- * a stall is architecturally valid (zero ticks skipped, R0 = 0).  The actual
- * host-thread idle sleep is added on top of this in a separate change.
+ * skipped while stalled.  idle_nap() sleeps the host thread but -- on CPU 0,
+ * which drives the wall-clock Cchip interval tick -- never past
+ * next_timer_fire, and the tick schedule is count-preserving with catch-up.
+ * No tick is ever skipped, so R0 = 0 is the true answer, not just the
+ * architecturally-permitted minimum.
  *
  * Privilege: the caller-mode check lives in DO_CALL_PAL (function < 0x40 with
  * state.cm != 0 traps OPCDEC before dispatch reaches this helper), same as
  * every other privileged PAL function.  PC: the interpreter advanced state.pc
  * past the CALL_PAL before decode, so like the other direct completions this
- * helper must not touch it.
+ * helper must not touch it.  Interrupt dispatch: the interpreter's step top
+ * and jit_run's dispatch gates both refuse compiled code while
+ * check_int/check_timers is pending, so an interrupt arriving during the nap
+ * is serviced before any further guest code runs.
  **/
 void CAlphaCPU::vmspal_call_wtint()
 {
@@ -688,6 +693,7 @@ void CAlphaCPU::vmspal_call_wtint()
 		fflush(stdout);
 	}
 
+	idle_nap();
 	r0 = 0;
 }
 

--- a/src/AlphaCPU_vmspal.cpp
+++ b/src/AlphaCPU_vmspal.cpp
@@ -649,10 +649,10 @@ void CAlphaCPU::vmspal_call_mtpr_datfx()
 }
 
 /**
- * CALL_PAL WTINT (0x3E): the SRM ROM's VMS PALcode has no 0x3E handler and
- * OPCDECs -- the exact fault the SRI SYS$IDLE driver probes for -- so
- * complete it natively.  R0 = 0 is truthful: the tick schedule is
- * count-preserving, no tick is skipped during the nap.  PC already advanced.
+ * Implementation of CALL_PAL WTINT opcode.
+ *
+ * Not a real VMS PALcode routine, but documented in Alpha Architecture Reference Manual
+ * Utilized by SRI's SYS$IDLE driver as an example
  **/
 void CAlphaCPU::vmspal_call_wtint()
 {

--- a/src/cpu_misc.h
+++ b/src/cpu_misc.h
@@ -322,6 +322,10 @@
     }                                                                  \
     else                                                               \
     {                                                                  \
+      /* Non-VMS (OSF) PALcode implements WTINT itself: nap the host   \
+       * thread first, then vector to the ROM unchanged. */            \
+      if(function == 0x3e)                                             \
+        idle_nap();                                                    \
       ENTER_NATIVE_CALL_PAL();                                         \
     }                                                                  \
   }

--- a/src/cpu_misc.h
+++ b/src/cpu_misc.h
@@ -105,7 +105,16 @@
   }                                                                    \
   else                                                                 \
   {                                                                    \
-    if(state.pal_vms)                                                  \
+    if((function == 0x3e) && idle_nap_enabled                          \
+       && (state.pal_base == U64(0x8000)))                             \
+    {                                                                  \
+      /* WTINT under VMS PALcode: complete natively -- the ROM has no  \
+       * 0x3e handler and would OPCDEC.  Keyed on PAL_BASE rather than \
+       * pal_vms because the JIT forces pal_vms false.  Off unless the \
+       * cpu config sets idle_nap = true. */                           \
+      vmspal_call_wtint();                                             \
+    }                                                                  \
+    else if(state.pal_vms)                                             \
     {                                                                  \
       switch(function)                                                 \
       {                                                                \
@@ -265,13 +274,6 @@
         vmspal_call_mtpr_datfx();                                      \
         break;                                                         \
                                                                 \
-      case 0x3e:  /* WTINT: complete natively -- the ROM PALcode has   \
-                   * no 0x3e handler and would OPCDEC (see             \
-                   * vmspal_call_wtint). Kernel-mode by the check      \
-                   * above. */                                         \
-        vmspal_call_wtint();                                           \
-        break;                                                         \
-                                                                \
       case 0x3f:  /* MFPR_WHAMI */                                     \
         vmspal_call_mfpr_whami();                                      \
         break;                                                         \
@@ -322,8 +324,8 @@
     }                                                                  \
     else                                                               \
     {                                                                  \
-      /* Non-VMS (OSF) PALcode implements WTINT itself: nap the host   \
-       * thread first, then vector to the ROM unchanged. */            \
+      /* Non-VMS PALcode implements WTINT itself: nap first (no-op     \
+       * unless enabled), then vector to the ROM unchanged. */         \
       if(function == 0x3e)                                             \
         idle_nap();                                                    \
       ENTER_NATIVE_CALL_PAL();                                         \

--- a/src/cpu_misc.h
+++ b/src/cpu_misc.h
@@ -39,7 +39,7 @@
   *
   * X-1.10       Camiel Vanderhoeven                             30-JAN-2008
   *      Always use set_pc or add_pc to change the program counter.
-  *
+  *  
   * X-1.9        Camiel Vanderhoeven                             30-JAN-2008
   *      Remember number of instructions left in current memory page, so
   *      that the translation-buffer doens't need to be consulted on every
@@ -322,9 +322,11 @@
     }                                                                  \
     else                                                               \
     {                                                                  \
-      if(function == 0x3e) /* Non-VMS WTINT implementation */          \
+      if(function == 0x3e) { /* Non-VMS WTINT implementation */        \
         idle_nap();                                                    \
+      } else { /* all other native PAL calls */                        \
       ENTER_NATIVE_CALL_PAL();                                         \
+      }                                                                \
     }                                                                  \
   }
 

--- a/src/cpu_misc.h
+++ b/src/cpu_misc.h
@@ -108,10 +108,8 @@
     if((function == 0x3e) && idle_nap_enabled                          \
        && (state.pal_base == U64(0x8000)))                             \
     {                                                                  \
-      /* WTINT under VMS PALcode: complete natively -- the ROM has no  \
-       * 0x3e handler and would OPCDEC.  Keyed on PAL_BASE rather than \
-       * pal_vms because the JIT forces pal_vms false.  Off unless the \
-       * cpu config sets idle_nap = true. */                           \
+      /* WTINT before the VMS vs native PAL decision, to accommodate   \
+       * the WTINT usage scenario under JIT */                         \
       vmspal_call_wtint();                                             \
     }                                                                  \
     else if(state.pal_vms)                                             \
@@ -324,9 +322,7 @@
     }                                                                  \
     else                                                               \
     {                                                                  \
-      /* Non-VMS PALcode implements WTINT itself: nap first (no-op     \
-       * unless enabled), then vector to the ROM unchanged. */         \
-      if(function == 0x3e)                                             \
+      if(function == 0x3e) /* Non-VMS WTINT implementation */          \
         idle_nap();                                                    \
       ENTER_NATIVE_CALL_PAL();                                         \
     }                                                                  \

--- a/src/cpu_misc.h
+++ b/src/cpu_misc.h
@@ -265,6 +265,13 @@
         vmspal_call_mtpr_datfx();                                      \
         break;                                                         \
                                                                 \
+      case 0x3e:  /* WTINT: complete natively -- the ROM PALcode has   \
+                   * no 0x3e handler and would OPCDEC (see             \
+                   * vmspal_call_wtint). Kernel-mode by the check      \
+                   * above. */                                         \
+        vmspal_call_wtint();                                           \
+        break;                                                         \
+                                                                \
       case 0x3f:  /* MFPR_WHAMI */                                     \
         vmspal_call_mfpr_whami();                                      \
         break;                                                         \

--- a/src/jit/jitengine.cpp
+++ b/src/jit/jitengine.cpp
@@ -263,6 +263,7 @@ SafeOp classify(uint32_t ins, bool pal_block)
       break;
     case 0x00: {                // CALL_PAL: compile valid standard funcs (priv 0x00-0x3f, unpriv 0x80-0xbf)
       const uint32_t fn = ins & 0x1FFFFFFF;
+      if (fn == 0x3E) break;    // WTINT: interpret -> DO_CALL_PAL completes it natively (vmspal_call_wtint)
       if (fn <= 0x3F || (fn >= 0x80 && fn <= 0xBF)) return OP_CALL_PAL;
       break;                    // SRM specials (0x1234xx) / invalid ranges -> interpret
     }

--- a/src/jit/jitengine.cpp
+++ b/src/jit/jitengine.cpp
@@ -263,7 +263,7 @@ SafeOp classify(uint32_t ins, bool pal_block)
       break;
     case 0x00: {                // CALL_PAL: compile valid standard funcs (priv 0x00-0x3f, unpriv 0x80-0xbf)
       const uint32_t fn = ins & 0x1FFFFFFF;
-      if (fn == 0x3E) break;    // WTINT: interpret -> DO_CALL_PAL completes it natively (vmspal_call_wtint)
+      if (fn == 0x3E) break;    // WTINT: interpret -> DO_CALL_PAL (native idle completion when enabled)
       if (fn <= 0x3F || (fn >= 0x80 && fn <= 0xBF)) return OP_CALL_PAL;
       break;                    // SRM specials (0x1234xx) / invalid ranges -> interpret
     }


### PR DESCRIPTION

## Summary

An idle Alpha guest (OpenVMS or Tru64) pins a host core at 100% per vCPU, because the es40 CPU thread never sleeps — there is no `usleep`/`nanosleep`/`sched_yield` anywhere in the interpreter or JIT dispatch loop. This PR gives the guest a way to hand the host thread back to the scheduler: it completes `CALL_PAL WTINT` (function `0x3E`, "wait for interrupt") **natively under VMS PALcode**, napping the host thread until an interrupt may be deliverable instead of vectoring `0x3E` into the SRM ROM (which has no handler for it and raises OPCDEC).

Deployed to a live OpenVMS Alpha 8.4 guest with the stock SRI/CHARON `SYS$IDLE` driver installed: **idle host CPU dropped from 100% to ~5-6%**, the guest clock stays second-exact against the host, and interactive latency is 0.06 s over telnet. The same change is what a natively-WTINT-emitting guest (Tru64) needs directly, though that is untested here (see Caveats).

This is the sibling of the long-open AXPbox idle request ([lenticularis39/axpbox#92](https://github.com/lenticularis39/axpbox/issues/92)); es40 has no idle issue on file yet.

**Commits:**
- `d08be39` — complete `CALL_PAL WTINT` natively under VMS PALcode, **immediate-return** (no nap yet). This is the causation-proof step: it isolates "does completing WTINT natively let the driver load?" from any sleep logic.
- `9c76b6f` — add the actual host-thread nap (`idle_nap()`) inside the native WTINT completion.

## Problem

`CALL_PAL WTINT` is the Alpha "wait for interrupt" idle primitive. On real hardware the CPU stalls in PALcode until an interrupt arrives. Under es40 there is no host-side stall anywhere in the CPU thread, so an idle guest — whose scheduler idle loop issues WTINT (Tru64's idle thread; OpenVMS with the SRI idle driver) — busy-spins a host core at 100% (per vCPU; a 2-CPU config burns ~200%). The `.cfg` `speed` knob is cosmetic (reported to the guest, not enforced), so it doesn't help.

## Root cause

es40 is the only Alpha emulator that boots the **genuine HP SRM ROM PALcode**. That ROM's VMS PALcode has **no handler for function `0x3E`** — so vectoring WTINT to the ROM raises OPCDEC (reserved-opcode) in the guest.

That matters beyond raw idle-spin, because of how the standard OpenVMS idle driver detects support. The SRI/CHARON `SYS$IDLE` driver's load-time init routine executes `CALL_PAL WTINT` under an established condition handler; if WTINT faults with `SS$_OPCDEC`, the handler sets the saved R0 to `SS$_UNSUPPORTED` (`0x0E4A`) and unwinds, so the load is refused. The gate is purely behavioral — *"does WTINT execute without faulting?"* — not a model-name check, HWRPB capability bit, or `CPU_POWER_MGMT` parameter.

On es40 the SRM ROM OPCDECs on `0x3E`, the handler fires, and the driver refuses to load with:

```
%SYSINIT-E, error loading SYS$IDLE, status = 00000E4A
```

This is why the driver loads and idles fine on every other Alpha emulator that implements WTINT itself (FreeAXP, CHARON, PersonalAlpha) but not on es40 — those emulators run their own console/PALcode, so WTINT never faults; es40 runs HP's real firmware, which never implemented a `0x3E` handler.

The gate was confirmed by disassembling the driver (extracting `IDLE.EXE` + the `SYS$IDLE_{LOAD,CALLOUT,NOCALLOUT}.OBJ` objects from the vdisk and reading the Alpha objects directly). The load-time init reads as:

```
ldl   a0, 0(t4)        ; a0 = *flag  (bit0 = "idle callout already enabled")
blbs  a0, done         ; if already enabled, skip the probe
ldq   ra, 88(t12)      ; ra = address of a condition handler (linkage +88)
stl   ra, 8(gp)        ; ESTABLISH that handler on this frame
call_pal wtint         ; <-- THE PROBE: execute PAL function 0x3E
...                    ; fall-through: set enable bit, return SS$_NORMAL
```

Four independent lines of evidence tie the `SS$_UNSUPPORTED` return to WTINT specifically: (1) the inline `call_pal wtint` immediately after handler establishment; (2) the objects import exactly the condition-handling machinery (`SS$_OPCDEC`, `CHF$IS_SIG_NAME`, `CHF$IH_MCH_SAVR0`, `SYS$UNWIND`, `SS$_RESIGNAL`, `SS$_UNSUPPORTED`) that exists only to catch a fault from executing an instruction — a data/model gate would import none of it; (3) the WTINT opcode (`3e 00 00 00`) appears at a load-time probe **and** a runtime idle callout site in each driver variant (the runtime callout is `whami → bump per-CPU idle counter → call_pal wtint`); (4) the driver's own release notes: *"execute a special palcode (WTINT)… if the system does not support powersaving then an error will be issued when loading the module. (Some systems just ignore the WTINT palcode and don't return an error…)"* — es40 is the error-returning kind, not the silent-ignore kind. This matches FreeAXP's history: the same driver machine-checked on WTINT until FreeAXP added support in 2010, then loaded and idled fine (including on OpenVMS 8.4).

Note that the runtime callout also issues WTINT on **every idle iteration**, so patching the driver to skip its load-time probe is not a fix — it just moves the OPCDEC from load time to a machine-check storm during idle. The emulator has to actually implement WTINT.

## Fix

Complete `CALL_PAL WTINT` in `DO_CALL_PAL` the same way es40 already directly-completes ~30 other PAL functions (`vmspal_call_*`), instead of vectoring `0x3E` to the ROM.

`d08be39` adds `vmspal_call_wtint()` (in `AlphaCPU_vmspal.cpp`) and dispatches `case 0x3e` to it inside the VMS-PALcode switch in `cpu_misc.h`:

- **R0 = 0** — the number of interval-clock ticks skipped while stalled. es40's Cchip tick schedule is count-preserving with catch-up, and on CPU 0 (which drives the wall-clock interval tick) `idle_nap()` never sleeps past `next_timer_fire`, so no tick is ever actually skipped — R0 = 0 is the true answer, not just the architecturally-permitted minimum.
- **PC untouched** — the interpreter already advanced `state.pc` past the `CALL_PAL` before decode, so like the other direct completions the helper must not touch it.
- **No ROM vector** — the whole point; the ROM has no `0x3E` handler and would OPCDEC.
- **Privilege is enforced by the existing guard**, unchanged. `case 0x3e` sits inside `DO_CALL_PAL`'s existing `function < 0x40 && state.cm != 0 → OPCDEC` check, so a user-mode WTINT still faults exactly as before — this closes the obvious guest-side DoS where an unprivileged process could otherwise loop instruction word `0x0000003e` to sleep the sole vCPU.
- **Non-VMS (OSF/Tru64) PALcode gets nap-then-vector** (in the second commit) — the OSF ROM implements WTINT, so that path naps the host thread and then vectors to the ROM unchanged.
- **`0x3E` is excluded from JIT trace compilation** (`jit/jitengine.cpp` `classify()` returns early on `fn == 0x3E`) so WTINT reaches the interpreter and `DO_CALL_PAL`.

`9c76b6f` then adds the actual sleep: `idle_nap()` inside `vmspal_call_wtint()`. `idle_nap()` sleeps the host thread in 100 µs poll steps (capped at 1 ms, CPU 0 never past `next_timer_fire`). The interpreter's step top and `jit_run`'s dispatch gates both refuse to run compiled guest code while `check_int`/`check_timers` is pending, so an interrupt that arrives during the nap is dispatched before any further guest code runs, with the saved PC already past the `CALL_PAL`.

Splitting the two commits keeps the causation proof clean: `d08be39` alone (immediate-return, no sleep) is enough to make the driver load — proving WTINT was the faulting op — and only `9c76b6f` changes host CPU behavior.

## Validation

Built and deployed to a live OpenVMS Alpha 8.4 guest (uniprocessor) with the **stock, unmodified** SRI `SYS$IDLE` driver installed (`PRODUCT INSTALL IDLE`, reboot):

- **Driver loads cleanly.** On the immediate-return binary, `SYS$IDLE.EXE` loads with no `%SYSINIT-E` — the `00000E4A` failure is gone. The PCSI install itself live-loads the driver, so the probe was observed passing twice (a one-shot image-space load-time probe PC, then the post-reboot SYSINIT probe PC), followed by the repeating runtime idle callout PC. The WTINT probe was the entire gate.
- **The runtime idle loop actually reaches WTINT.** Tens of millions of native WTINT completions logged on the immediate-return binary (66M+), confirming the driver's hot-patch of the idle loop takes effect and — critically — that es40's JIT trace invalidation (IMB → icache flush → `jit_flush_blocks`) lets the patched idle path reach the inserted callout rather than spinning a stale compiled trace.
- **Idle host CPU: 100% → ~5-6%** on the nap binary. WTINT call rate collapses when idle (the liveness marker that fired every ~25 s on the immediate-return binary goes minutes without firing), i.e. real sleeping, not fast-spinning.
- **Clock second-exact.** After ~8 min napping, guest `SHOW TIME` matches host `date` to the second — as predicted by the count-preserving tick schedule + the CPU-0 nap bound (R0 = 0 is literally true; no tick is skipped).
- **Responsive.** Interactive command latency 0.06 s over telnet while napping; `SYS$IDLE` present in SDA `SHOW EXECUTIVE`. A 60k-iteration DCL busy loop drove the emulator back to full utilization and completed normally, then returned to ~0% idle immediately — interrupts and real work are unaffected.

(Validation ran on these same changes as originally built against a slightly older `main`; the branch as filed is the identical WTINT code rebased onto current `main` (v0.76), with some inert config-gated debug scaffolding from the investigation dropped, and compile-verified on FreeBSD 15.1/clang after the rebase.)

The prior near-miss is also explained: an earlier revision napped the host thread but then still vectored `0x3E` into the ROM. Because the ROM OPCDECs on `0x3E`, the driver's probe still faulted and refused to load — a guest-invisible hook cannot pass a probe that tests guest-visible behavior. Returning R0 = 0 without the ROM vector is the operative change.

## How to reproduce / obtain the driver

The driver is not part of this PR and we do not redistribute it — obtain it yourself.

On real HP OpenVMS Alpha there is no native idle path; the scheduler idle loop is a permanent busy-poll (there is no HWRPB power-management field and no VMS-Alpha powersaving primitive — `CPU_POWER_MGMT` is documented for OpenVMS Integrity/I64 only). The thing that inserts WTINT into the OpenVMS idle path is the **SRI/CHARON idle-cpu driver** — "SRI AXPVMS IDLE V1.2", authored by Jur van der Burg / Software Resources International (SRI, later Stromasys). It is long-standing SRI/Stromasys freeware, historically distributed gratis bundled with the CHARON-AXP / PersonalAlpha emulators.

To get it:

1. It ships as a virtual disk file named **`idle_vms_pkg.vdisk`** inside CHARON-AXP / PersonalAlpha (CHARON keeps it under "Virtual Disk Images"). The kit inside the vdisk is `[AXP]SRI-AXPVMS-IDLE-V0102--1.PCSI`.
2. A publicly reachable CHARON-AXP package is the Internet Archive item **https://archive.org/details/charon-axp** (a single `Charon AXP.zip`, ~78 MB). You want specifically the `idle_vms_pkg.vdisk` file from inside that zip — that single vdisk is all you need; ignore the rest of the package.
3. To install: mount the vdisk under VMS (`MOUNT/OVER=ID/NOWRITE`), `PRODUCT INSTALL IDLE` from `[AXP]`, then reboot. (PCSI relinks `SYS$IDLE.EXE` against the target's own starlet at install, so it is version-portable.)

With this patched es40, the driver loads and its runtime idle callout drives the host CPU down; without the patch it installs fine but fails to load with `%SYSINIT-E … status = 00000E4A`.

## Caveats / scope

- **Uniprocessor.** Validated on a 1-CPU guest, which is the safe case. SMP idle is separate, unaudited work: waking a napping sibling CPU requires cross-thread IPI wakeup and flag synchronization that this PR does not touch. Frame this change as uniprocessor.
- **Tru64 untested here.** Tru64/OSF issues WTINT natively (no driver needed), and the OSF path in this change naps then vectors to the ROM (which does implement WTINT for OSF PALcode), so it should benefit — but it has not been exercised in this validation. Only OpenVMS 8.4 was measured.
- **VMS PALcode only for the native-completion path.** The direct R0 = 0 / no-ROM-vector completion is gated on `state.pal_vms`; OSF PALcode is deliberately left on nap-then-vector, since its ROM implements `0x3E`.
- Privilege behavior is unchanged by construction (the existing `< 0x40 && cm != 0` guard), so user-mode WTINT still takes the architected fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
