### PR TITLE
Abstract class for network support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(ES40 VERSION 0.75.4 LANGUAGES C CXX)
 
 option(ES40_DISABLE_SDL "Disable SDL for headless builds" OFF)
 option(ES40_DISABLE_NETWORKING "Disable PCap/networking for networkless builds" OFF)
+option(ES40_DISABLE_TAP "Disable TAP networking even on platforms that support it (Linux/FreeBSD/NetBSD)" OFF)
 option(ES40_DISABLE_LSS_LSM "Disable LSS/LSM (lockstep) builds." OFF)
 option(ES40_DISABLE_IDB "Disable IDB (built-in debugger) builds." OFF)
 option(ES40_DISABLE_ASMJIT "Disable ASMJIT" ON)
@@ -37,14 +38,35 @@ if (NOT ES40_DISABLE_SDL)
     find_package(SDL3 REQUIRED)
 endif()
 
+set(ES40_HAVE_PCAP FALSE)
+set(ES40_HAVE_TAP FALSE)
+
 if (NOT ES40_DISABLE_NETWORKING)
     if (WIN32)
         #if (NOT NPCAP_DIR)
         #    set(NPCAP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../NPCAP")
         #endif()
         #find_package(NPCap REQUIRED)
+        set(ES40_HAVE_PCAP TRUE)
     else()
-        find_package(PCap REQUIRED)
+        # pcap is optional on Unix-like hosts as long as TAP support covers
+        # the platform; it's still tried first since it also works for
+        # host OSes/setups TAP doesn't (e.g. wireless adapters, or hosts
+        # where the user doesn't want to grant CAP_NET_ADMIN).
+        find_package(PCap)
+        if (PCap_FOUND)
+            set(ES40_HAVE_PCAP TRUE)
+        endif()
+
+        if (NOT ES40_DISABLE_TAP AND (CMAKE_SYSTEM_NAME STREQUAL "Linux" OR
+                                       CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR
+                                       CMAKE_SYSTEM_NAME STREQUAL "NetBSD"))
+            set(ES40_HAVE_TAP TRUE)
+        endif()
+
+        if (NOT ES40_HAVE_PCAP AND NOT ES40_HAVE_TAP)
+            message(FATAL_ERROR "Networking was requested (ES40_DISABLE_NETWORKING=OFF) but neither libpcap nor TAP support is available for this platform/build. Install libpcap, or configure with -DES40_DISABLE_NETWORKING=ON to build without networking.")
+        endif()
     endif()
 endif()
 
@@ -169,11 +191,16 @@ if (WIN32)
 endif()
 
 if (NOT ES40_DISABLE_NETWORKING)
-    list(APPEND ES40_CFG_DEFINITIONS HAVE_PCAP)
-    if (WIN32)
-        #list(APPEND ES40_CFG_LIBRARIES NPCap::NPCap)
-    else()
-        list(APPEND ES40_CFG_LIBRARIES PCap::PCap)
+    if (ES40_HAVE_PCAP)
+        list(APPEND ES40_CFG_DEFINITIONS HAVE_PCAP)
+        if (WIN32)
+            #list(APPEND ES40_CFG_LIBRARIES NPCap::NPCap)
+        else()
+            list(APPEND ES40_CFG_LIBRARIES PCap::PCap)
+        endif()
+    endif()
+    if (ES40_HAVE_TAP)
+        list(APPEND ES40_CFG_DEFINITIONS HAVE_TAP_NET)
     endif()
 endif()
 
@@ -262,6 +289,9 @@ list(APPEND ES40_SOURCES
     src/Keyboard.cpp
     src/lockstep.cpp
     src/MPU401.cpp
+    src/NetworkBackend.cpp
+    src/NetworkPcap.cpp
+    src/NetworkTap.cpp
     src/PCIDevice.cpp
     src/Port80.cpp
     src/S3Trio64.cpp
@@ -305,11 +335,16 @@ if (NOT ES40_DISABLE_SDL)
 endif()
 
 if (NOT ES40_DISABLE_NETWORKING)
-    list(APPEND ES40_DEFINITIONS HAVE_PCAP)
-    if (WIN32)
-        # list(APPEND ES40_LIBRARIES NPCap::NPCap)
-    else()
-        list(APPEND ES40_LIBRARIES PCap::PCap)
+    if (ES40_HAVE_PCAP)
+        list(APPEND ES40_DEFINITIONS HAVE_PCAP)
+        if (WIN32)
+            # list(APPEND ES40_LIBRARIES NPCap::NPCap)
+        else()
+            list(APPEND ES40_LIBRARIES PCap::PCap)
+        endif()
+    endif()
+    if (ES40_HAVE_TAP)
+        list(APPEND ES40_DEFINITIONS HAVE_TAP_NET)
     endif()
 endif()
 

--- a/configure.ac
+++ b/configure.ac
@@ -184,14 +184,24 @@ AC_ARG_ENABLE([pcap],
   [],
   [enable_pcap=yes])
 
+# Allow disabling TAP support (Linux/FreeBSD/NetBSD only) independently of pcap.
+AC_ARG_ENABLE([tap],
+  [AS_HELP_STRING([--disable-tap],[Disable TAP device networking (Linux/FreeBSD/NetBSD only)])],
+  [],
+  [enable_tap=yes])
+
+have_pcap=no
 AS_IF([test "x$enable_pcap" != "xno"], [
   case "$host_os" in
     darwin*)
       # On macOS, use our own AM_PATH_PCAP (m4/libpcap.m4)
       AM_PATH_PCAP(
-        CXXFLAGS="$CXXFLAGS $PCAP_CFLAGS -DHAVE_PCAP"
-        LIBS="$LIBS $PCAP_LIBS"
-        ,:)
+        [
+          AC_DEFINE([HAVE_PCAP],[1],[Use PCAP])
+          CXXFLAGS="$CXXFLAGS $PCAP_CFLAGS -DHAVE_PCAP"
+          LIBS="$LIBS $PCAP_LIBS"
+          have_pcap=yes
+        ],:)
       ;;
     *)
       PKG_CHECK_MODULES([PCAP],[libpcap >= 0.8],
@@ -199,12 +209,33 @@ AS_IF([test "x$enable_pcap" != "xno"], [
           AC_DEFINE([HAVE_PCAP],[1],[Use PCAP])
           CXXFLAGS="$CXXFLAGS $PCAP_CFLAGS -DHAVE_PCAP"
           LIBS="$LIBS $PCAP_LIBS"
+          have_pcap=yes
         ],
-        [
-          AC_MSG_FAILURE([libpcap >= 0.8 is required unless --disable-pcap is used])
-        ])
+        [:])
       ;;
   esac
+])
+
+# TAP device support: on Linux, FreeBSD and NetBSD, a TAP-based backend is
+# available even without libpcap. Opening an existing device is always
+# possible with just a file descriptor and (on Linux only) an ioctl; no
+# extra library is required, so this only needs a host_os check.
+have_tap=no
+AS_IF([test "x$enable_tap" != "xno"], [
+  case "$host_os" in
+    linux*|freebsd*|kfreebsd*-gnu|netbsd*)
+      AC_DEFINE([HAVE_TAP_NET],[1],[Use TAP device networking])
+      CXXFLAGS="$CXXFLAGS -DHAVE_TAP_NET"
+      have_tap=yes
+      ;;
+    *)
+      ;;
+  esac
+])
+
+AS_IF([test "x$enable_pcap" != "xno" -a "x$have_pcap" = "xno" \
+       -a "x$have_tap" = "xno"], [
+  AC_MSG_FAILURE([libpcap >= 0.8 is required on this platform unless --disable-pcap is used (or, on Linux/FreeBSD/NetBSD, TAP support can be used instead: don't pass --disable-tap)])
 ])
 
 # Use our own method to search for X11

--- a/src/Configurator.cpp
+++ b/src/Configurator.cpp
@@ -144,7 +144,7 @@
 //#include "Cirrus.h" // to be re-added and fixed in the future
 #include "FloppyController.h"
 #include "gui/plugin.h"
-#if defined(HAVE_PCAP)
+#if defined(HAVE_PCAP) || defined(HAVE_TAP_NET)
 #include "DEC21143.h"
 #endif
 #include "LSI53C1020.h"
@@ -728,7 +728,7 @@ static const char* const kv_vga[] = { "rom", 0 };
 static const char* const kv_lsi53c1020[] = { "flash", "rom", "firmware", 0 };
 static const char* const kv_dec21143[] = {
   "adapter", "mac", "queue", "crc", "trace_packets",
-  "autonegotiate_delay", 0 };
+  "type", "autonegotiate_delay", 0 };
 static const char* const kv_disk_file[] = {
   "file", "model_number", "serial_number", "serial_num", "rev_number",
   "rev_num", "read_only", "cdrom", "autocreate_size", 0 };
@@ -852,10 +852,10 @@ void CConfigurator::initialize()
 				myName);
 	}
 
-#if !defined(HAVE_PCAP)
+#if !defined(HAVE_PCAP) && !defined(HAVE_TAP_NET)
 	if (myFlags & IS_NIC)
 		FAILURE_2(Configuration,
-			"Class %s for %s needs compilation with libpcap support", myValue,
+			"Class %s for %s needs compilation with libpcap or TAP support", myValue,
 			myName);
 #endif
 	if (myFlags & IS_PCI)
@@ -1013,7 +1013,7 @@ void CConfigurator::initialize()
 		break;
 #endif
 
-#if defined(HAVE_PCAP)
+#if defined(HAVE_PCAP) || defined(HAVE_TAP_NET)
 
 	case c_dec21143:
 		myDevice = new CDEC21143(this, (CSystem*)pParent->get_device(), pcibus,

--- a/src/DEC21143.cpp
+++ b/src/DEC21143.cpp
@@ -157,7 +157,7 @@
   **/
 #include "StdAfx.h"
 
-#if defined(HAVE_PCAP)
+#if defined(HAVE_PCAP) || defined(HAVE_TAP_NET)
 #include "DEC21143.h"
 #include "System.h"
 #include <string.h>
@@ -427,80 +427,12 @@ u32             dec21143_cfg_mask[64] = {
 
 int CDEC21143::nic_num = 0;
 
-#ifdef _WIN32
-/* Pointers to the real functions. */
-static const char *(*f_pcap_lib_version)(void);
-static int (*f_pcap_findalldevs)(pcap_if_t **, char *);
-static void (*f_pcap_freealldevs)(void *);
-static pcap_t* (*f_pcap_open_live)(const char *, int, int, int, char *);
-static int (*f_pcap_compile)(void *, void *, const char *, int, bpf_u_int32);
-static int (*f_pcap_setfilter)(void *, void *);
-static const unsigned char
-    *(*f_pcap_next)(void *, void *);
-static int (*f_pcap_sendpacket)(void *, const unsigned char *, int);
-static void (*f_pcap_close)(void *);
-static int (*f_pcap_setnonblock)(void *, int, char *);
-static int (*f_pcap_set_immediate_mode)(void *, int);
-static int (*f_pcap_set_promisc)(void *, int);
-static int (*f_pcap_set_snaplen)(void *, int);
-static int (*f_pcap_dispatch)(void *, int, pcap_handler callback, unsigned char *user);
-static void *(*f_pcap_create)(const char *, char *);
-static int (*f_pcap_activate)(void *);
-static char *(*f_pcap_geterr)(void *);
-static pcap_t* (*f_pcap_open)(const char *source, int snaplen, int flags, int read_timeout, struct pcap_rmtauth *auth, char *errbuf);
-static int (*f_pcap_next_ex)(pcap_t *, struct pcap_pkthdr **, const unsigned char **);
-#endif
-
 /**
  * Constructor.
  **/
 CDEC21143::CDEC21143(CConfigurator* confg, CSystem* c, int pcibus, int pcidev) : CPCIDevice(confg, c, pcibus, pcidev), mySemaphore(0, 1)
 {
-#ifdef _WIN32
-	{
-	    char npcap_dir[512];
-    	GetSystemDirectoryA(npcap_dir, 480);
-    	strcat(npcap_dir, "\\Npcap");
-    	SetDllDirectoryA(npcap_dir);	
-		auto libhandle = LoadLibraryA("wpcap.dll");
-    	SetDllDirectoryA(NULL); /* reset the DLL search path */
-		if (!libhandle) {
-			FAILURE(Runtime, "Failed to load wpcap.dll");
-		}
-		f_pcap_lib_version = (const char *(*)())GetProcAddress(libhandle, "pcap_lib_version");
-		f_pcap_findalldevs = (int (*)(pcap_if_t **, char *))GetProcAddress(libhandle, "pcap_findalldevs");
-		f_pcap_freealldevs = (void (*)(void *))GetProcAddress(libhandle, "pcap_freealldevs");
-		f_pcap_open_live   = (pcap_t *(*)(const char *, int, int, int, char *))GetProcAddress(libhandle, "pcap_open_live");
-		f_pcap_open   = (pcap_t* (*)(const char *, int , int , int , pcap_rmtauth *, char *))GetProcAddress(libhandle, "pcap_open");
-		f_pcap_compile = (int (*)(void *, void *, const char *, int, bpf_u_int32))GetProcAddress(libhandle, "pcap_compile");
-		f_pcap_setfilter = (int (*)(void *, void *))GetProcAddress(libhandle, "pcap_setfilter");
-		f_pcap_next = (const unsigned char *(*)(void *, void *))GetProcAddress(libhandle, "pcap_next");
-		f_pcap_sendpacket = (int (*)(void *, const unsigned char *, int))GetProcAddress(libhandle, "pcap_sendpacket");
-		f_pcap_close = (void (*)(void *))GetProcAddress(libhandle, "pcap_close");
-		f_pcap_setnonblock = (int (*)(void *, int, char *))GetProcAddress(libhandle, "pcap_setnonblock");
-		f_pcap_set_immediate_mode = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_immediate_mode");
-		f_pcap_set_promisc = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_promisc");
-		f_pcap_set_snaplen = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_snaplen");
-		f_pcap_dispatch = (int (*)(void *, int, pcap_handler callback, unsigned char *user))GetProcAddress(libhandle, "pcap_dispatch");
-		f_pcap_create = (void * (*)(const char *, char *))GetProcAddress(libhandle, "pcap_create");
-		f_pcap_geterr = (char *(*)(void *))GetProcAddress(libhandle, "pcap_geterr");
-		f_pcap_next_ex = (int (*)(pcap *, pcap_pkthdr **, const unsigned char **))GetProcAddress(libhandle, "pcap_next_ex");
-
-		#define pcap_findalldevs f_pcap_findalldevs
-		#define pcap_open f_pcap_open
-		#define pcap_sendpacket f_pcap_sendpacket
-		#define pcap_close f_pcap_close
-		#define pcap_setnonblock f_pcap_setnonblock
-		#define pcap_setfilter f_pcap_setfilter
-		#define pcap_compile f_pcap_compile
-		#define pcap_geterr f_pcap_geterr
-		#define pcap_next_ex f_pcap_next_ex
-
-		#define PCAP_ERROR -1
-		#define PCAP_OPENFLAG_PROMISCUOUS 0x00000001
-		#define PCAP_OPENFLAG_NOCAPTURE_LOCAL 0x00000008
-	}
-#endif
+	net_backend = nullptr;
 }
 
 /**
@@ -508,94 +440,20 @@ CDEC21143::CDEC21143(CConfigurator* confg, CSystem* c, int pcibus, int pcidev) :
  **/
 void CDEC21143::init()
 {
-	pcap_if_t* alldevs;
-
-	pcap_if_t* d;
-	unsigned int inum;
-	unsigned int i = 0;
-	char        errbuf[PCAP_ERRBUF_SIZE];
 	char* cfg;
 
 	add_function(0, dec21143_cfg_data, dec21143_cfg_mask);
 
-	cfg = myCfg->get_text_value("adapter");
-	if (!cfg)
+	net_backend = create_network_backend(devid_string, myCfg);
+	if (!net_backend)
+		FAILURE(Runtime, "Could not create a network backend (see messages above)");
+
+	if (!net_backend->init(devid_string, myCfg))
 	{
-		printf("\n%s: Choose a network adapter to connect to:\n", devid_string);
-		if (pcap_findalldevs(&alldevs, errbuf) == -1)
-		{
-			FAILURE_1(Runtime, "Error in pcap_findalldevs_ex: %s", errbuf);
-		}
-
-		/* Print the list */
-		for (d = alldevs; d; d = d->next)
-		{
-			printf("%d. %s\n    ", ++i, d->name);
-			if (d->description)
-				printf(" (%s)\n", d->description);
-			else
-				printf(" (No description available)\n");
-		}
-
-		if (i == 0)
-			FAILURE(Runtime, "No network interfaces found");
-
-		if (i == 1)
-			inum = 1;
-		else
-		{
-			for (;;)
-			{
-				char input_buf[64];
-				int  parsed;
-
-				printf("%%NIC-Q-NICNO: Enter the interface number (1-%d): ", i);
-				fflush(stdout);
-
-				if (fgets(input_buf, sizeof(input_buf), stdin) == NULL)
-					FAILURE(Runtime, "Unexpected end of input while selecting network interface");
-
-				if (sscanf(input_buf, "%d", &parsed) != 1 || parsed < 1 || (unsigned int)parsed > i)
-				{
-					printf("%%NIC-W-BADSEL: Invalid selection. Please enter a number between 1 and %d.\n", i);
-					continue;
-				}
-
-				inum = (unsigned int)parsed;
-				break;
-			}
-		}
-
-		/* Jump to the selected adapter */
-		for (d = alldevs, i = 0; i < inum - 1; d = d->next, i++);
-
-		cfg = d->name;
+		delete net_backend;
+		net_backend = nullptr;
+		FAILURE(Runtime, "Could not initialize the network backend (see messages above)");
 	}
-
-#if defined(WIN32)
-
-	// Opening with pcap_open on Windows allows specification of PCAP_OPENFLAG_NOCAPTURE_LOCAL,
-	// which stops the pcap device from seeing it's own transmitted packets.
-	//
-	// This is important because:
-	//    1. Real ethernet cards don't reflect packets except while in loopback mode(s).
-	//    2. Reflecting all packets increases inbound packet processing and host load.
-	//    3. DECNET Phase IV will think a reflected packet is from another node
-	//            that has the same DECNET Phase IV address (AA-xx-xx-xx-xx-xx),
-	//            and will panic on startup and abort.
-	//    4. Libpcap doesn't reflect packets, and we want winpcap/libpcap processing to be identical.
-	// Loopback packets are handled via direct entry in the receive queue.
-	if ((fp = (pcap_t*)pcap_open(cfg, 65536 /*snaplen: capture entire packets */,
-		PCAP_OPENFLAG_PROMISCUOUS | PCAP_OPENFLAG_NOCAPTURE_LOCAL /*promiscuous */,
-		10 /*packet buffer timeout: [ms] */, 0 /* auth structure */, errbuf)) == NULL) // connect to pcap...
-#else
-	if ((fp = pcap_open_live(cfg, 65536 /*snaplen: capture entire packets */,
-		1 /*promiscuous */, 10 /*packet buffer timeout: [ms] */, errbuf)) == NULL) // connect to pcap...
-#endif
-		FAILURE_2(Runtime, "Error opening adapter %s:\n %s", cfg, errbuf);
-
-	if (pcap_setnonblock(fp, 1, errbuf) == PCAP_ERROR)
-		FAILURE_2(Runtime, "Error setting adapter %s non-blocking:\n %s", cfg, errbuf);
 
 	// set default mac = Digital ethernet prefix: 08-00-2B + hexified "ES40" + nic number
 	state.mac[0] = 0x08;
@@ -713,8 +571,10 @@ CDEC21143::~CDEC21143()
 {
 	stop_threads();
 
-	if (fp != nullptr) {
-		pcap_close(fp);
+	if (net_backend != nullptr) {
+		net_backend->close();
+		delete net_backend;
+		net_backend = nullptr;
 	}
 	delete rx_queue;
 	/* Free TX scratch on device teardown (not on ResetNIC, which expects it alive). */
@@ -761,8 +621,8 @@ void CDEC21143::check_state()
 
 void CDEC21143::receive_process()
 {
-	struct pcap_pkthdr* packet_header;
-	const unsigned char* packet_data = NULL;
+	const u8* packet_data = NULL;
+	int       packet_len = 0;
 
 	// if receive process active
 	if (state.reg[CSR_OPMODE / 8] & OPMODE_SR)
@@ -771,11 +631,11 @@ void CDEC21143::receive_process()
 		// get packets from host nic if not in internal loopback mode
 		if (!(state.reg[CSR_OPMODE / 8] & OPMODE_OM_INTLOOP))
 		{
-			while (pcap_next_ex(fp, &packet_header, &packet_data) > 0)
+			while (net_backend->receive(&packet_data, &packet_len) > 0)
 			{
 				if (trace_packets)
-					trace_packet("RX", packet_data, packet_header->caplen);
-				bool  resl = rx_queue->add_tail(packet_data, packet_header->caplen,
+					trace_packet("RX", packet_data, packet_len);
+				bool  resl = rx_queue->add_tail(packet_data, packet_len,
 					calc_crc, true);
 				state.reg[CSR_SIASTAT / 8] |= SIASTAT_TRA;  //set 10bT activity
 			}
@@ -1891,11 +1751,10 @@ int CDEC21143::dec21143_tx()
 			/* Only transmit to wire if no loopback is active and frame size is legal. */
 			if (!frame_too_long && !(state.reg[CSR_OPMODE / 8] & OPMODE_OM))
 			{
-				// printf("pcap send: %d bytes   \n", state.tx.cur_buf_len);
+				// printf("send: %d bytes   \n", state.tx.cur_buf_len);
 				if (trace_packets)
 					trace_packet("TX", state.tx.cur_buf, state.tx.cur_buf_len);
-				if (pcap_sendpacket(fp, state.tx.cur_buf, state.tx.cur_buf_len))
-					printf("Error sending the packet: %s\n", pcap_geterr(fp));
+				net_backend->send(state.tx.cur_buf, state.tx.cur_buf_len);
 			}
 
 			/* In internal or external loopback, inject into RX queue iff RX is running and size ok. */
@@ -1957,7 +1816,6 @@ void CDEC21143::SetupFilter()
 {
 	u8    mac[16][6];
 	char  mac_txt[16][20];
-	char  filter[1000];
 	int   i;
 	int   j;
 	int   numUnique;
@@ -2029,58 +1887,32 @@ void CDEC21143::SetupFilter()
 	for (i = 0; i < numUnique; i++)
 		printf("Unique MAC[%d] = %s. \n", i, mac_txt[unique[i]]);
 #endif
-	filter[0] = '\0';
 
-	/* Build BPF per CSR6[PR,PM,IF,RA]; always allow broadcasts. */
+	/* No setup-frame received yet: fall back to filtering on our own MAC,
+	 * same as before this was split out into the network backend. */
+	if (numUnique == 0)
+	{
+		memcpy(mac[0], state.mac, 6);
+		numUnique = 1;
+	}
+	else
+	{
+		/* Compact the unique addresses down to the front of the array,
+		 * since that's what the backend interface expects. */
+		u8 compact[16][6];
+		for (i = 0; i < numUnique; i++)
+			memcpy(compact[i], mac[unique[i]], 6);
+		memcpy(mac, compact, sizeof(u8) * 6 * numUnique);
+	}
+
+	/* Filtering semantics per CSR6[PR,PM,IF,RA]; the backend decides how
+	   (or whether) to actually apply this on the host side.  */
 	bool promisc = (state.reg[CSR_OPMODE / 8] & OPMODE_PR) != 0;
 	bool receive_all = (state.reg[CSR_OPMODE / 8] & OPMODE_RA) != 0;
 	bool pass_multi = (state.reg[CSR_OPMODE / 8] & OPMODE_PM) != 0;
 	bool inverse = (state.reg[CSR_OPMODE / 8] & OPMODE_IF) != 0;
 
-	strcpy(filter, "ether broadcast");
-
-	if (!(promisc || receive_all)) {
-		if (pass_multi) {
-			strcat(filter, " or ether multicast");
-		}
-		char list[800]; list[0] = 0;
-		if (numUnique == 0) {
-			/* Fallback to our own MAC if no setup-frame yet. */
-			char self[20];
-			sprintf(self, "%02x:%02x:%02x:%02x:%02x:%02x",
-				state.mac[0], state.mac[1], state.mac[2],
-				state.mac[3], state.mac[4], state.mac[5]);
-			strcat(list, "ether dst "); strcat(list, self);
-		}
-		else {
-			for (i = 0; i < numUnique; i++) {
-				strcat(list, (i == 0) ? "ether dst " : " or ether dst ");
-				strcat(list, mac_txt[unique[i]]);
-			}
-		}
-		if (inverse) {
-			strcat(filter, " or (not ("); strcat(filter, list); strcat(filter, "))");
-		}
-		else {
-			strcat(filter, " or ("); strcat(filter, list); strcat(filter, ")");
-		}
-	} /* else PR/RA: leave filter as match-all broadcasts + everything (no extra terms) */
-
-
-#if defined(DEBUG_NIC_FILTER)
-	printf("FILTER = %s.   \n", filter);
-#endif
-	/* In promiscuous/receive-all we still compile an empty/very permissive filter. */
-	if (promisc || receive_all) {
-		/* Let the OS accept everything: empty expr compiles to "match all". */
-		filter[0] = '\0';
-	}
-
-	if (pcap_compile(fp, &fcode, filter, 1, 0xffffffff) < 0)
-		FAILURE_1(Logic, "Unable to compile the packet filter (%s)", filter);
-
-	if (pcap_setfilter(fp, &fcode) < 0)
-		FAILURE(Runtime, "Error setting the filter.");
+	net_backend->set_filter(mac, numUnique, promisc, receive_all, pass_multi, inverse);
 }
 
 /**
@@ -2429,4 +2261,4 @@ void CDEC21143::update_irq()
 }
 
 
-#endif //defined(HAVE_PCAP)
+#endif //defined(HAVE_PCAP) || defined(HAVE_TAP_NET)

--- a/src/DEC21143.h
+++ b/src/DEC21143.h
@@ -94,73 +94,11 @@
 #include "PCIDevice.h"
 #include "DEC21143_mii.h"
 #include "DEC21143_tulipreg.h"
-#if defined(WIN32)
-#define HAVE_REMOTE
-#include <winsock.h>
-#else
-#include <pcap.h>
-#endif
 #include "Ethernet.h"
+#include "NetworkBackend.h"
 #include "base/Semaphore.h"
 #include <atomic>
 #include <chrono>
-
-#if defined(WIN32)
-typedef int          bpf_int32;
-typedef unsigned int bpf_u_int32;
-
-/*
- * The instruction data structure.
- */
-struct bpf_insn {
-    unsigned short code;
-    unsigned char  jt;
-    unsigned char  jf;
-    bpf_u_int32    k;
-};
-
-/*
- * Structure for "pcap_compile()", "pcap_setfilter()", etc..
- */
-struct bpf_program {
-    unsigned int     bf_len;
-    struct bpf_insn *bf_insns;
-};
-
-typedef struct pcap_if pcap_if_t;
-
-#    define PCAP_ERRBUF_SIZE 256
-
-struct pcap_pkthdr {
-    struct timeval ts;
-    bpf_u_int32    caplen;
-    bpf_u_int32    len;
-};
-
-struct pcap_if {
-    struct pcap_if *next;
-    char           *name;
-    char           *description;
-    void           *addresses;
-    bpf_u_int32     flags;
-};
-
-struct pcap_send_queue {
-    unsigned int maxlen; /* Maximum size of the queue, in bytes. This
-             variable contains the size of the buffer field. */
-    unsigned int len;    /* Current size of the queue, in bytes. */
-    char *buffer; /* Buffer containing the packets to be sent. */
-};
-
-typedef struct pcap_send_queue pcap_send_queue;
-
-typedef void (*pcap_handler)(unsigned char *user, const struct pcap_pkthdr *h, const unsigned char *bytes);
-
-typedef struct pcap pcap_t;
-typedef struct pcap_dumper pcap_dumper_t;
-typedef struct pcap_if pcap_if_t;
-typedef struct pcap_addr pcap_addr_t;
-#endif
 
   /**
    * \brief Emulated DEC 21143 NIC device.
@@ -218,12 +156,10 @@ private:
   void                set_tx_state(int tx_state);
   void                set_rx_state(int rx_state);
 
+  inline u32          bswap32_local(u32 v);
 
-  inline u32 bswap32_local(u32 v);
-    
-  CPacketQueue* rx_queue;
-  pcap_t* fp;
-  struct bpf_program  fcode;
+  CPacketQueue*       rx_queue;
+  CNetworkBackend*    net_backend;
   bool                calc_crc;
   bool                trace_packets;
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -77,6 +77,9 @@ es40_SOURCES = AliM1543C.cpp \
        FloppyController.cpp \
        Keyboard.cpp \
        lockstep.cpp \
+       NetworkBackend.cpp \
+       NetworkPcap.cpp \
+       NetworkTap.cpp \
        PCIDevice.cpp \
        Port80.cpp \
        S3Trio64.cpp \

--- a/src/NetworkBackend.cpp
+++ b/src/NetworkBackend.cpp
@@ -39,26 +39,27 @@ CNetworkBackend* create_network_backend(const char *devid_string,
 {
 	char *type = cfg->get_text_value("type");
 
-	if (type && !strcasecmp(type, "tap")) {
-#if defined(HAVE_TAP_NET)
-		return new CNetworkTap();
-#endif
-		printf ("%s: \"tap\" support not compiled in.");
-		return nullptr;
-	}
-
-	if (type && !strcasecmp(type, "pcap")) {
+	// pcap is the default when no type is specified.
+	if (!type || !strcasecmp(type, "pcap")) {
 #if defined(HAVE_PCAP)
 		return new CNetworkPcap();
 #else
-		printf ("%s: \"pcap\" support not compiled in.");
+		printf("%s: \"pcap\" support not compiled in.\n", devid_string);
 		return nullptr;
 #endif
 	}
 
-	if (type)
-		printf("%s: Unknown network backend type \"%s\"; expected \"pcap\" or "
-		       "\"tap\".\n", devid_string, type);
+	if (!strcasecmp(type, "tap")) {
+#if defined(HAVE_TAP_NET)
+		return new CNetworkTap();
+#else
+		printf("%s: \"tap\" support not compiled in.\n", devid_string);
+		return nullptr;
+#endif
+	}
+
+	printf("%s: Unknown network backend type \"%s\"; expected \"pcap\" or "
+	       "\"tap\".\n", devid_string, type);
 
 	return nullptr;
 

--- a/src/NetworkBackend.cpp
+++ b/src/NetworkBackend.cpp
@@ -1,0 +1,67 @@
+/* ES40 emulator.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Although this is not required, the author would appreciate being notified of,
+ * and receiving any modifications you may make to the source code that might serve
+ * the general public.
+ */
+
+#include "StdAfx.h"
+
+#if defined(HAVE_PCAP) || defined(HAVE_TAP_NET)
+
+#include "NetworkBackend.h"
+#include "Configurator.h"
+
+#if defined(HAVE_PCAP)
+#include "NetworkPcap.h"
+#endif
+
+#if defined(HAVE_TAP_NET)
+#include "NetworkTap.h"
+#endif
+
+CNetworkBackend* create_network_backend(const char *devid_string,
+                                        CConfigurator *cfg)
+{
+	char *type = cfg->get_text_value("type");
+
+	if (type && !strcasecmp(type, "tap")) {
+#if defined(HAVE_TAP_NET)
+		return new CNetworkTap();
+#endif
+		printf ("%s: \"tap\" support not compiled in.");
+		return nullptr;
+	}
+
+	if (type && !strcasecmp(type, "pcap")) {
+#if defined(HAVE_PCAP)
+		return new CNetworkPcap();
+#else
+		printf ("%s: \"pcap\" support not compiled in.");
+		return nullptr;
+#endif
+	}
+
+	if (type)
+		printf("%s: Unknown network backend type \"%s\"; expected \"pcap\" or "
+		       "\"tap\".\n", devid_string, type);
+
+	return nullptr;
+
+}
+
+#endif /* defined(HAVE_PCAP) || defined(HAVE_TAP_NET)  */

--- a/src/NetworkBackend.h
+++ b/src/NetworkBackend.h
@@ -1,0 +1,106 @@
+/* ES40 emulator.
+ * Copyright (C) 2007-2008 by the ES40 Emulator Project
+ * Copyright (C) 2020 Tomáš Glozar
+ *
+ * WWW    : https://github.com/ES40-Emu/es40
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Although this is not required, the author would appreciate being notified of,
+ * and receiving any modifications you may make to the source code that might serve
+ * the general public.
+ */
+
+/**
+ * \file
+ * Abstract interface separating the emulated DEC 21143 NIC from the host
+ * networking method used to get packets on and off the wire.
+ *
+ * Implementations:
+ *  - CNetworkPcap  : libpcap / npcap (Windows, and any Unix with libpcap).
+ *  - CNetworkTap   : TAP device (Linux, FreeBSD, NetBSD).
+ **/
+#if !defined(INCLUDED_NETWORK_BACKEND_H_)
+#define INCLUDED_NETWORK_BACKEND_H_
+
+#include "StdAfx.h"
+
+class CConfigurator;
+
+/**
+ * \brief Abstract network backend interface.
+ **/
+class CNetworkBackend {
+public:
+	virtual ~CNetworkBackend() {}
+
+	/**
+	 * Initialize the backend from configuration. devid_string is used only
+	 * for log/error message prefixes. Returns true on success; on failure it
+	 * should have already printed a descriptive message.
+	 **/
+	virtual bool init(const char *devid_string, CConfigurator *cfg) = 0;
+
+	/**
+	 * Send a packet to the host network. Returns 0 on success, -1 on error.
+	 **/
+	virtual int send(const u8 *data, int len) = 0;
+
+	/**
+	 * Receive a packet from the host network (non-blocking).
+	 * On success, sets *data and *len and returns 1. The buffer pointed to
+	 * by *data is only valid until the next call to receive() and must not
+	 * be freed by the caller.
+	 * If no packet is currently available, returns 0.
+	 * On error, returns -1.
+	 **/
+	virtual int receive(const u8 **data, int *len) = 0;
+
+	/**
+	 * Set up MAC-based receive filtering, mirroring the emulated NIC's CSR6
+	 * bits:
+	 *  - mac_list/num_macs: up to 16 perfect-filter MAC addresses (entries
+	 *    that are all-zero should be ignored).
+	 *  - promiscuous:     CSR6.PR - accept everything, ignore all other
+	 *                      arguments.
+	 *  - receive_all:     CSR6.RA - accept everything (like promiscuous, but
+	 *                      distinguished for backends that log the reason).
+	 *  - pass_multicast:  CSR6.PM - also accept all multicast traffic.
+	 *  - inverse:         CSR6.IF - invert the perfect-filter address match.
+	 *
+	 * Backends that can't express host-side filtering at this granularity
+	 * (e.g. a TAP device, which only ever sees frames the kernel already
+	 * routed to it) are free to make this a no-op.
+	 **/
+	virtual void set_filter(u8 mac_list[][6], int num_macs, bool promiscuous,
+	                        bool receive_all, bool pass_multicast,
+	                        bool inverse) = 0;
+
+	/**
+	 * Close the backend and release any resources (file descriptors,
+	 * library handles, created interfaces, ...).
+	 **/
+	virtual void close() = 0;
+};
+
+/**
+ * Factory: create the network backend selected by the "type" configuration
+ * value ("pcap", the default, or "tap"). Returns nullptr (after printing a
+ * diagnostic) if the requested backend isn't available in this build or on
+ * this platform.
+ **/
+CNetworkBackend *create_network_backend(const char *devid_string, CConfigurator *cfg);
+
+#endif /* !defined(INCLUDED_NETWORK_BACKEND_H_)  */

--- a/src/NetworkPcap.cpp
+++ b/src/NetworkPcap.cpp
@@ -1,0 +1,352 @@
+/* ES40 emulator.
+ * Copyright (C) 2007-2008 by the ES40 Emulator Project
+ * Copyright (C) 2020 Tomáš Glozar
+ *
+ * WWW    : https://github.com/ES40-Emu/es40
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Although this is not required, the author would appreciate being notified of,
+ * and receiving any modifications you may make to the source code that might serve
+ * the general public.
+ */
+
+#include "StdAfx.h"
+
+#if defined(HAVE_PCAP)
+
+#include "NetworkPcap.h"
+#include "Configurator.h"
+
+#ifdef _WIN32
+/* Pointers to the real functions, resolved at runtime from wpcap.dll. */
+static const char *(*f_pcap_lib_version)(void);
+static int (*f_pcap_findalldevs)(pcap_if_t **, char *);
+static void (*f_pcap_freealldevs)(void *);
+static pcap_t *(*f_pcap_open_live)(const char *, int, int, int, char *);
+static int (*f_pcap_compile)(void *, void *, const char *, int, bpf_u_int32);
+static int (*f_pcap_setfilter)(void *, void *);
+static const unsigned char *(*f_pcap_next)(void *, void *);
+static int (*f_pcap_sendpacket)(void *, const unsigned char *, int);
+static void (*f_pcap_close)(void *);
+static int (*f_pcap_setnonblock)(void *, int, char *);
+static int (*f_pcap_set_immediate_mode)(void *, int);
+static int (*f_pcap_set_promisc)(void *, int);
+static int (*f_pcap_set_snaplen)(void *, int);
+static int (*f_pcap_dispatch)(void *, int, pcap_handler callback,
+                              unsigned char *user);
+static void *(*f_pcap_create)(const char *, char *);
+static int (*f_pcap_activate)(void *);
+static char *(*f_pcap_geterr)(void *);
+static pcap_t *(*f_pcap_open)(const char *source, int snaplen, int flags,
+                              int read_timeout, struct pcap_rmtauth *auth,
+                              char *errbuf);
+static int (*f_pcap_next_ex)(pcap_t *, struct pcap_pkthdr **,
+                             const unsigned char **);
+static bool wpcap_loaded = false;
+#endif
+
+CNetworkPcap::CNetworkPcap() : fp(nullptr), opened(false) {
+	memset(&fcode, 0, sizeof(fcode));
+
+#ifdef _WIN32
+	if (!wpcap_loaded) {
+		char npcap_dir[512];
+		GetSystemDirectoryA(npcap_dir, 480);
+		strcat(npcap_dir, "\\Npcap");
+		SetDllDirectoryA(npcap_dir);
+		auto libhandle = LoadLibraryA("wpcap.dll");
+		SetDllDirectoryA(NULL); /* reset the DLL search path */
+		if (!libhandle) {
+			FAILURE(Runtime, "Failed to load wpcap.dll");
+		}
+
+		f_pcap_lib_version = (const char *(*)())GetProcAddress(libhandle, "pcap_lib_version");
+		f_pcap_findalldevs = (int (*)(pcap_if_t **, char *))GetProcAddress(libhandle, "pcap_findalldevs");
+		f_pcap_freealldevs = (void (*)(void *))GetProcAddress(libhandle, "pcap_freealldevs");
+		f_pcap_open_live   = (pcap_t *(*)(const char *, int, int, int, char *))GetProcAddress(libhandle, "pcap_open_live");
+		f_pcap_open        = (pcap_t *(*)(const char *, int, int, int, pcap_rmtauth *, char *))GetProcAddress(libhandle, "pcap_open");
+		f_pcap_compile     = (int (*)(void *, void *, const char *, int, bpf_u_int32))GetProcAddress(libhandle, "pcap_compile");
+		f_pcap_setfilter   = (int (*)(void *, void *))GetProcAddress(libhandle, "pcap_setfilter");
+		f_pcap_next        = (const unsigned char *(*)(void *, void *))GetProcAddress(libhandle, "pcap_next");
+		f_pcap_sendpacket  = (int (*)(void *, const unsigned char *, int))GetProcAddress(libhandle, "pcap_sendpacket");
+		f_pcap_close       = (void (*)(void *))GetProcAddress(libhandle, "pcap_close");
+		f_pcap_setnonblock = (int (*)(void *, int, char *))GetProcAddress(libhandle, "pcap_setnonblock");
+		f_pcap_set_immediate_mode = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_immediate_mode");
+		f_pcap_set_promisc = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_promisc");
+		f_pcap_set_snaplen = (int (*)(void *, int))GetProcAddress(libhandle, "pcap_set_snaplen");
+		f_pcap_dispatch    = (int (*)(void *, int, pcap_handler callback, unsigned char *user))GetProcAddress(libhandle, "pcap_dispatch");
+		f_pcap_create      = (void *(*)(const char *, char *))GetProcAddress(libhandle, "pcap_create");
+		f_pcap_geterr      = (char *(*)(void *))GetProcAddress(libhandle, "pcap_geterr");
+		f_pcap_next_ex     = (int (*)(pcap *, pcap_pkthdr **, const unsigned char **))GetProcAddress(libhandle, "pcap_next_ex");
+
+#define pcap_findalldevs f_pcap_findalldevs
+#define pcap_open f_pcap_open
+#define pcap_sendpacket f_pcap_sendpacket
+#define pcap_close f_pcap_close
+#define pcap_setnonblock f_pcap_setnonblock
+#define pcap_setfilter f_pcap_setfilter
+#define pcap_compile f_pcap_compile
+#define pcap_geterr f_pcap_geterr
+#define pcap_next_ex f_pcap_next_ex
+
+#define PCAP_ERROR -1
+#define PCAP_OPENFLAG_PROMISCUOUS 0x00000001
+#define PCAP_OPENFLAG_NOCAPTURE_LOCAL 0x00000008
+
+		wpcap_loaded = true;
+	}
+#endif
+}
+
+CNetworkPcap::~CNetworkPcap()
+{
+	close();
+}
+
+bool CNetworkPcap::init(const char *devid_string, CConfigurator *cfg)
+{
+	pcap_if_t *alldevs;
+	pcap_if_t *d;
+	unsigned int inum;
+	unsigned int i = 0;
+	char errbuf[PCAP_ERRBUF_SIZE];
+
+	char *adapter = cfg->get_text_value("adapter");
+	if (!adapter) {
+		printf("\n%s: Choose a network adapter to connect to:\n", devid_string);
+		if (pcap_findalldevs(&alldevs, errbuf) == -1) {
+			printf("%s: Error in pcap_findalldevs: %s\n", devid_string, errbuf);
+			return false;
+		}
+
+		for (d = alldevs; d; d = d->next) {
+			printf("%d. %s\n    ", ++i, d->name);
+			if (d->description)
+				printf(" (%s)\n", d->description);
+			else
+				printf(" (No description available)\n");
+		}
+
+		if (i == 0) {
+			printf("%s: No network interfaces found\n", devid_string);
+			return false;
+		}
+
+		if (i == 1)
+			inum = 1;
+		else {
+			for (;;) {
+				char input_buf[64];
+				int  parsed;
+
+				printf("%%NIC-Q-NICNO: Enter the interface number (1-%d): ", i);
+				fflush(stdout);
+
+				if (fgets(input_buf, sizeof(input_buf), stdin) == NULL) {
+					printf("%s: Unexpected end of input while selecting network "
+					       "interface\n", devid_string);
+					return false;
+				}
+
+				if (sscanf(input_buf, "%d", &parsed) != 1
+				    || parsed < 1
+				    || (unsigned int)parsed > i) {
+					printf("%%NIC-W-BADSEL: Invalid selection. Please enter a number "
+					       "between 1 and %d.\n", i);
+					continue;
+				}
+
+				inum = (unsigned int)parsed;
+				break;
+			}
+		}
+
+		for (d = alldevs, i = 0; i < inum - 1; d = d->next, i++)
+			;
+
+		adapter = d->name;
+	}
+
+#if defined(WIN32)
+	// Opening with pcap_open on Windows allows specification of
+	// PCAP_OPENFLAG_NOCAPTURE_LOCAL, which stops the pcap device from seeing
+	// it's own transmitted packets.
+	//
+	// This is important because:
+	//    1. Real ethernet cards don't reflect packets except while in
+	//       loopback mode(s).
+	//    2. Reflecting all packets increases inbound packet processing and
+	//       host load.
+	//    3. DECNET Phase IV will think a reflected packet is from another
+	//       node that has the same DECNET Phase IV address
+	//       (AA-xx-xx-xx-xx-xx), and will panic on startup and abort.
+	//    4. Libpcap doesn't reflect packets, and we want winpcap/libpcap
+	//       processing to be identical.
+	// Loopback packets are handled via direct entry in the receive queue.
+	if ((fp = (pcap_t *)pcap_open(
+	         adapter, 65536 /*snaplen: capture entire packets */,
+	         PCAP_OPENFLAG_PROMISCUOUS |
+	             PCAP_OPENFLAG_NOCAPTURE_LOCAL /*promiscuous */,
+	         10 /*packet buffer timeout: [ms] */, 0 /* auth structure */,
+	         errbuf)) == NULL) // connect to pcap...
+#else
+	if ((fp = pcap_open_live(adapter, 65536 /*snaplen: capture entire packets */,
+	                         1 /*promiscuous */,
+	                         10 /*packet buffer timeout: [ms] */,
+	                         errbuf)) == NULL) // connect to pcap...
+#endif
+	{
+		printf("%s: Error opening adapter %s:\n %s\n", devid_string, adapter, errbuf);
+		return false;
+	}
+
+	if (pcap_setnonblock(fp, 1, errbuf) == PCAP_ERROR) {
+		printf("%s: Error setting adapter %s non-blocking:\n %s\n", devid_string, adapter, errbuf);
+		pcap_close(fp);
+		fp = nullptr;
+		return false;
+	}
+
+	opened = true;
+	printf("%s: Using pcap adapter %s\n", devid_string, adapter);
+	return true;
+}
+
+int CNetworkPcap::send(const u8 *data, int len)
+{
+	if (!fp)
+		return -1;
+	if (pcap_sendpacket(fp, data, len)) {
+		printf("Error sending the packet: %s\n", pcap_geterr(fp));
+		return -1;
+	}
+	return 0;
+}
+
+int CNetworkPcap::receive(const u8 **data, int *len)
+{
+	if (!fp)
+		return -1;
+	struct pcap_pkthdr   *packet_header;
+	const unsigned char  *packet_data = NULL;
+	int res = pcap_next_ex(fp, &packet_header, &packet_data);
+	if (res > 0) {
+		*data = packet_data;
+		*len = packet_header->caplen;
+		return 1;
+	}
+	if (res == 0)
+		return 0; /* timeout, no packet  */
+	return -1;        /* error  */
+}
+
+void CNetworkPcap::set_filter(u8 mac_list[][6], int num_macs,
+                               bool promiscuous, bool receive_all,
+                               bool pass_multicast, bool inverse)
+{
+	if (!fp)
+		return;
+
+	char mac_txt[16][20];
+	char filter[1000];
+	int  numUnique = 0;
+	int  unique[16];
+	int  count = num_macs > 16 ? 16 : num_macs;
+
+	for (int i = 0; i < count; i++) {
+		bool zero = (mac_list[i][0] | mac_list[i][1] | mac_list[i][2] |
+		             mac_list[i][3] | mac_list[i][4] | mac_list[i][5]) == 0;
+		if (zero)
+			continue;
+		sprintf(mac_txt[i], "%02x:%02x:%02x:%02x:%02x:%02x",
+		        mac_list[i][0], mac_list[i][1], mac_list[i][2],
+		        mac_list[i][3], mac_list[i][4], mac_list[i][5]);
+
+		bool u = true;
+		for (int j = 0; j < numUnique; j++) {
+			if (memcmp(mac_list[i], mac_list[unique[j]], 6) == 0) {
+				u = false;
+				break;
+			}
+		}
+		if (u) {
+			unique[numUnique] = i;
+			numUnique++;
+		}
+	}
+
+	filter[0] = '\0';
+	strcpy(filter, "ether broadcast");
+
+	if (!(promiscuous || receive_all)) {
+		char list[800];
+
+		if (pass_multicast)
+			strcat(filter, " or ether multicast");
+
+		list[0] = '\0';
+		if (numUnique == 0) {
+			/* No addresses learned yet; there's no "our own MAC"
+			   to fall back to at this layer (the caller owns
+			   that), so just leave the list empty and rely on the
+			   broadcast/multicast terms above.  */
+		} else {
+			for (int i = 0; i < numUnique; i++) {
+				strcat(list, (i == 0) ? "ether dst " : " or ether dst ");
+				strcat(list, mac_txt[unique[i]]);
+			}
+		}
+
+		if (list[0]) {
+			if (inverse) {
+				strcat(filter, " or (not (");
+				strcat(filter, list);
+				strcat(filter, "))");
+			} else {
+				strcat(filter, " or (");
+				strcat(filter, list);
+				strcat(filter, ")");
+			}
+		}
+	} /* else PR/RA: leave filter as match-all broadcasts + everything */
+
+	/* In promiscuous/receive-all we still compile an empty/very permissive filter. */
+	if (promiscuous || receive_all) {
+		/* Let the OS accept everything: empty expr compiles to "match all". */
+		filter[0] = '\0';
+	}
+
+	if (pcap_compile(fp, &fcode, filter, 1, 0xffffffff) < 0) {
+		printf("Unable to compile the packet filter (%s)\n", filter);
+		return;
+	}
+
+	if (pcap_setfilter(fp, &fcode) < 0)
+		printf("Error setting the filter.\n");
+
+	return;
+}
+
+void CNetworkPcap::close()
+{
+	if (fp) {
+		pcap_close(fp);
+		fp = nullptr;
+	}
+	opened = false;
+}
+
+#endif /* HAVE_PCAP  */

--- a/src/NetworkPcap.h
+++ b/src/NetworkPcap.h
@@ -1,0 +1,118 @@
+/* ES40 emulator.
+ *
+ * WWW    : https://github.com/ES40-Emu/es40
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Although this is not required, the author would appreciate being notified of,
+ * and receiving any modifications you may make to the source code that might serve
+ * the general public.
+ */
+#ifndef INCLUDED_NETWORK_PCAP_H_
+#define INCLUDED_NETWORK_PCAP_H_
+
+#include "NetworkBackend.h"
+
+#if defined(WIN32)
+#define HAVE_REMOTE
+#include <winsock.h>
+#else
+#include <pcap.h>
+#endif
+
+#if defined(WIN32)
+typedef int          bpf_int32;
+typedef unsigned int bpf_u_int32;
+
+/*
+ * The instruction data structure.
+ */
+struct bpf_insn {
+	unsigned short code;
+	unsigned char  jt;
+	unsigned char  jf;
+	bpf_u_int32    k;
+};
+
+/*
+ * Structure for "pcap_compile()", "pcap_setfilter()", etc..
+ */
+struct bpf_program {
+	unsigned int     bf_len;
+	struct bpf_insn* bf_insns;
+};
+
+typedef struct pcap_if pcap_if_t;
+
+#define PCAP_ERRBUF_SIZE 256
+
+struct pcap_pkthdr {
+	struct timeval ts;
+	bpf_u_int32    caplen;
+	bpf_u_int32    len;
+};
+
+struct pcap_if {
+	struct pcap_if* next;
+	char*           name;
+	char*           description;
+	void*           addresses;
+	bpf_u_int32     flags;
+};
+
+struct pcap_send_queue {
+	unsigned int maxlen; /* Maximum size of the queue, in bytes. This
+	                        variable contains the size of the buffer field.  */
+	unsigned int len;    /* Current size of the queue, in bytes.  */
+	char *buffer;        /* Buffer containing the packets to be sent.  */
+};
+
+typedef struct pcap_send_queue pcap_send_queue;
+
+typedef void (*pcap_handler)(unsigned char *user, const struct pcap_pkthdr *h, const unsigned char *bytes);
+
+typedef struct pcap pcap_t;
+typedef struct pcap_dumper pcap_dumper_t;
+typedef struct pcap_if pcap_if_t;
+typedef struct pcap_addr pcap_addr_t;
+#endif
+
+/**
+ * \brief libpcap / npcap network backend.
+ *
+ * On Windows, wpcap.dll is loaded dynamically at runtime (from the Npcap
+ * install directory) the first time a CNetworkPcap is constructed, mirroring
+ * what CDEC21143 used to do directly.
+ **/
+class CNetworkPcap : public CNetworkBackend {
+public:
+	CNetworkPcap();
+	virtual ~CNetworkPcap();
+
+	virtual bool init(const char *devid_string, CConfigurator *cfg);
+	virtual int  send(const u8 *data, int len);
+	virtual int  receive(const u8 **data, int *len);
+	virtual void set_filter(u8 mac_list[][6], int num_macs,
+	                        bool promiscuous, bool receive_all,
+	                        bool pass_multicast, bool inverse);
+	virtual void close();
+
+private:
+	pcap_t*             fp;
+	struct bpf_program  fcode;
+	bool                opened;
+};
+
+#endif /* INCLUDED_NETWORK_PCAP_H_  */

--- a/src/NetworkTap.cpp
+++ b/src/NetworkTap.cpp
@@ -1,0 +1,204 @@
+/* ES40 emulator.
+ *
+ * WWW    : https://github.com/ES40-Emu/es40
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Although this is not required, the author would appreciate being notified of,
+ * and receiving any modifications you may make to the source code that might serve
+ * the general public.
+ */
+
+#include "StdAfx.h"
+
+#if defined(HAVE_TAP_NET)
+
+#include "NetworkTap.h"
+#include "Configurator.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#if defined(__linux__)
+#include <linux/if_tun.h>
+#include <linux/sockios.h>
+
+// Bridge ioctls may not be defined in every libc's headers.
+#ifndef SIOCBRADDIF
+#define SIOCBRADDIF 0x89a2
+#endif
+#ifndef SIOCBRADDBR
+#define SIOCBRADDBR 0x89a0
+#endif
+
+#elif defined(__FreeBSD__) || defined(__NetBSD__)
+#include <sys/sockio.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#endif
+
+CNetworkTap::CNetworkTap():
+	tap_fd(-1),
+	devid_for_log(nullptr) {
+
+	memset(ifname, 0, sizeof(ifname));
+}
+
+CNetworkTap::~CNetworkTap() { close(); }
+
+// ---------------------------------------------------------------------
+// Device open.
+//
+// Linux: a single shared clone device (/dev/net/tun) is opened, and the
+// TUNSETIFF ioctl both selects (attaches to) an existing persistent tap
+// interface and creates a new one if it doesn't exist yet - the kernel
+// decides which based on whether the name is already taken and whether
+// the caller has CAP_NET_ADMIN.
+//
+// FreeBSD/NetBSD: there is no separate clone-and-bind step. A TAP device
+// *is* a character device node, normally /dev/tapN, and using it is just
+// open("/dev/tapN", O_RDWR) - exactly like any other file. If the
+// interface doesn't exist yet (ENOENT/ENXIO), it can be instantiated with
+// the generic BSD "interface cloning" ioctl SIOCIFCREATE, which is the
+// same mechanism "ifconfig tapN create" uses; afterwards the device node
+// can be opened normally.
+// ---------------------------------------------------------------------
+bool CNetworkTap::tap_open(const char *devid_string, const char *name) {
+#if defined(__linux__)
+	struct ifreq ifr;
+
+	tap_fd = open("/dev/net/tun", O_RDWR);
+	if (tap_fd < 0) {
+		printf("%s: Cannot open /dev/net/tun: %s\n", devid_string, strerror(errno));
+		return false;
+	}
+
+	memset(&ifr, 0, sizeof(ifr));
+	ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
+	if (name && name[0])
+		strncpy(ifr.ifr_name, name, IFNAMSIZ - 1);
+
+	if (ioctl(tap_fd, TUNSETIFF, &ifr) < 0) {
+		printf("%s: TUNSETIFF failed for %s: %s\n", devid_string, name, strerror(errno));
+		::close(tap_fd);
+		tap_fd = -1;
+		return false;
+	}
+
+	return true;
+
+#elif defined(__FreeBSD__) || defined(__NetBSD__)
+	tap_fd = open(name, O_RDWR);
+	if (tap_fd < 0) {
+		printf("%s: Cannot open %s: %s\n", devid_string, name, strerror(errno));
+		return false;
+	}
+
+	return true;
+#else
+#error "HAVE_TAP_NET defined on an unsupported platform"
+#endif
+}
+
+bool CNetworkTap::init(const char *devid_string, CConfigurator *cfg)
+{
+	devid_for_log = devid_string;
+	char *adapter = cfg->get_text_value("adapter");
+	const char *tap_name = adapter ? adapter : "tap0";
+
+	if (!tap_open(devid_string, adapter))
+		return false;
+
+	int flags = fcntl(tap_fd, F_GETFL, 0);
+	if (flags < 0 || fcntl(tap_fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+		printf("%s: Cannot set TAP fd non-blocking: %s\n", devid_string, strerror(errno));
+		close();
+		return false;
+	}
+
+	return true;
+}
+
+int CNetworkTap::send(const u8 *data, int len) {
+	if (tap_fd < 0)
+		return -1;
+	ssize_t n = write(tap_fd, data, len);
+	if (n < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK)
+			return 0; /* Host-side queue full; drop the packet like a real wire would.  */
+		printf("TAP: Error sending packet: %s\n", strerror(errno));
+		return -1;
+	}
+
+	return 0;
+}
+
+int CNetworkTap::receive(const u8 **data, int *len)
+{
+	if (tap_fd < 0)
+		return -1;
+	ssize_t n = read(tap_fd, rx_buf, sizeof(rx_buf));
+
+	if (n > 0) {
+		*data = rx_buf;
+		*len = (int)n;
+		return 1;
+	}
+
+	if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+		return 0; // no packet available
+	if (n == 0)
+		return 0;
+
+	return -1;
+}
+
+void CNetworkTap::set_filter(u8 mac_list[][6], int num_macs,
+                              bool promiscuous, bool receive_all,
+                              bool pass_multicast, bool inverse)
+{
+	// TAP devices only ever deliver frames the kernel has already routed to
+	// this interface, so there's no host-side capture filter to program
+	// (unlike libpcap on a shared physical link). The emulated NIC's own
+	// setup-frame handling still does perfect/hash filtering in software
+	// for anything delivered here.
+	(void) mac_list;
+	(void) num_macs;
+	(void) promiscuous;
+	(void) receive_all;
+	(void) pass_multicast;
+	(void) inverse;
+
+	return;
+}
+
+void CNetworkTap::close()
+{
+	if (tap_fd >= 0) {
+		::close(tap_fd);
+		tap_fd = -1;
+	}
+
+	return;
+}
+
+#endif /* defined(HAVE_TAP_NET)  */

--- a/src/NetworkTap.h
+++ b/src/NetworkTap.h
@@ -1,0 +1,70 @@
+/* ES40 emulator.
+ *
+ * WWW    : https://github.com/ES40-Emu/es40
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Although this is not required, the author would appreciate being notified of,
+ * and receiving any modifications you may make to the source code that might serve
+ * the general public.
+ */
+
+/**
+ * \file
+ * TAP device network backend.
+ *
+ * Host support:
+ *  - Linux: Opens the shared clone device /dev/net/tun and binds
+ *           it to a named tap interface via the TUNSETIFF ioctl.
+ *  - *BSD:  A TAP device is a character device node (usually
+ *           /dev/tapN).
+ **/
+#ifndef INCLUDED_NETWORK_TAP_H_
+#define INCLUDED_NETWORK_TAP_H_
+
+#include "NetworkBackend.h"
+
+#if defined(HAVE_TAP_NET)
+
+#include <net/if.h>
+
+class CNetworkTap: public CNetworkBackend {
+public:
+	CNetworkTap();
+	virtual ~CNetworkTap();
+
+	virtual bool init(const char *devid_string, CConfigurator *cfg);
+	virtual int  send(const u8 *data, int len);
+	virtual int  receive(const u8 **data, int *len);
+	virtual void set_filter(u8 mac_list[][6], int num_macs,
+	                        bool promiscuous, bool receive_all,
+	                        bool pass_multicast, bool inverse);
+	virtual void close();
+
+private:
+	int  tap_fd;
+	char ifname[IFNAMSIZ];
+	unsigned char rx_buf[2048]; /* Max ethernet frame, rounded up.  */
+
+	const char *devid_for_log;
+
+	// --- device open/create: platform-specific implementation lives in
+	//     NetworkTap.cpp, split by #if defined(__linux__) / BSD. ---
+	bool tap_open(const char *devid_string, const char *name);
+};
+
+#endif /* defined(HAVE_TAP_NET)  */
+
+#endif /* !defined(INCLUDED_NETWORK_TAP_H_)  */

--- a/src/Visual Studio/es40.vcxproj
+++ b/src/Visual Studio/es40.vcxproj
@@ -2208,7 +2208,8 @@
     <ClCompile Include="..\MPU401.cpp" />
     <ClCompile Include="..\Configurator.cpp" />
     <ClCompile Include="..\DEC21143.cpp" />
-    <!-- Further files need to be added. -->
+    <ClCompile Include="..\NetworkBackend.cpp" />
+    <ClCompile Include="..\NetworkPcap.cpp" />
     <ClCompile Include="..\Disk.cpp" />
     <ClCompile Include="..\DiskController.cpp" />
     <ClCompile Include="..\DiskDevice.cpp" />

--- a/src/Visual Studio/es40.vcxproj
+++ b/src/Visual Studio/es40.vcxproj
@@ -2210,6 +2210,9 @@
     <ClCompile Include="..\DEC21143.cpp" />
     <ClCompile Include="..\NetworkBackend.cpp" />
     <ClCompile Include="..\NetworkPcap.cpp" />
+    <ClCompile Include="..\NetworkTap.cpp">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\Disk.cpp" />
     <ClCompile Include="..\DiskController.cpp" />
     <ClCompile Include="..\DiskDevice.cpp" />
@@ -2300,6 +2303,9 @@
     <ClInclude Include="..\es40_debug.h" />
     <ClInclude Include="..\es40_endian.h" />
     <ClInclude Include="..\Ethernet.h" />
+    <ClInclude Include="..\NetworkBackend.h" />
+    <ClInclude Include="..\NetworkPcap.h" />
+    <ClInclude Include="..\NetworkTap.h" />
     <ClInclude Include="..\Flash.h" />
     <ClInclude Include="..\FloppyController.h" />
     <ClInclude Include="..\gui\gui.h" />

--- a/src/Visual Studio/es40.vcxproj
+++ b/src/Visual Studio/es40.vcxproj
@@ -2208,6 +2208,7 @@
     <ClCompile Include="..\MPU401.cpp" />
     <ClCompile Include="..\Configurator.cpp" />
     <ClCompile Include="..\DEC21143.cpp" />
+    <!-- Further files need to be added. -->
     <ClCompile Include="..\Disk.cpp" />
     <ClCompile Include="..\DiskController.cpp" />
     <ClCompile Include="..\DiskDevice.cpp" />

--- a/src/Visual Studio/es40.vcxproj.filters
+++ b/src/Visual Studio/es40.vcxproj.filters
@@ -81,6 +81,15 @@
     <ClCompile Include="..\DEC21143.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\NetworkBackend.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NetworkPcap.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\NetworkTap.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\Disk.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -309,6 +318,15 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\Ethernet.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NetworkBackend.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NetworkPcap.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\NetworkTap.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\Flash.h">

--- a/src/es40-cfg.cpp
+++ b/src/es40-cfg.cpp
@@ -898,7 +898,7 @@ int main(int argc, char* argv[])
 	card_q.setDefault("none");
 	card_q.setExplanation("Choose what PCI card you'd like to add. Choose none if you have no more cards to add.");
 	card_q.addAnswer("none", "", "No more cards to add");
-#if defined(HAVE_PCAP)
+#if defined(HAVE_PCAP) || defined(HAVE_TAP_NET)
 	card_q.addAnswer("nic", "dec21143", "DEC 21143 Network Interface (1 max)");
 #endif
 	card_q.addAnswer("scsi", "sym53c810", "Symbios 53C810 narrow SCSI controller");
@@ -942,38 +942,74 @@ int main(int argc, char* argv[])
 			 */
 			card_q.dropChoice("nic");
 
+#if defined(HAVE_PCAP) || defined(HAVE_TAP_NET)
+			string nic_type = "pcap";
+
+#if defined(HAVE_PCAP) && defined(HAVE_TAP_NET)
+			MultipleChoiceQuestion type_q;
+			type_q.setQuestion("How should this NIC connect to the host network?");
+			type_q.setDefault("pcap");
+			type_q.setExplanation(
+				"pcap captures/injects packets on an existing host adapter "
+				"(works everywhere, but usually requires a bridge/promiscuous "
+				"setup on the host to reach a wired LAN).\n"
+				"tap uses a TAP virtual network device (Linux/FreeBSD/NetBSD "
+				"only), which plays more nicely with host firewalling and "
+				"bridging.");
+			type_q.addAnswer("pcap", "pcap", "libpcap (default, all platforms)");
+			type_q.addAnswer("tap", "tap", "TAP device (Linux/FreeBSD/NetBSD)");
+			nic_type = type_q.ask();
+			os << "    type = \"" << nic_type << "\";\n";
+#elif defined(HAVE_TAP_NET)
+			nic_type = "tap";
+#endif
+
+			if (nic_type == "tap") {
+#if defined(HAVE_TAP_NET)
+				FreeTextQuestion tap_q;
+				tap_q.setQuestion("What should the TAP device be named?");
+				tap_q.setExplanation(
+					"On Linux this can be any name (e.g. \"tap0\"). "
+					"FreeBSD/NetBSD this must be the device name, eg. "
+					"/dev/tapN or similar.");
+				tap_q.setDefault("tap0");
+				os << "    adapter = \"" << tap_q.ask() << "\";\n";
+#endif
+			} else {
 #if defined(HAVE_PCAP)
-			MultipleChoiceQuestion if_q;
-			if_q.setQuestion("What host network interface should we connect to (answer ? for a list)?");
-			if_q.setExplanation("Choose 'list' to get a list at run-time.");
-			if_q.addAnswer("list", "", "Get a list at run-time");
+				MultipleChoiceQuestion if_q;
+				if_q.setQuestion("What host network interface should we connect to (answer ? for a list)?");
+				if_q.setExplanation("Choose 'list' to get a list at run-time.");
+				if_q.addAnswer("list", "", "Get a list at run-time");
 
-			/* Get a list of network interfaces and
-			 * add them to the list.
-			 */
-			pcap_if_t* alldevs;
-			pcap_if_t* d;
-			char        errbuf[PCAP_ERRBUF_SIZE];
-
-			if (pcap_findalldevs(&alldevs, errbuf) == -1)
-			{
-				/* No devices to add.
+				/* Get a list of network interfaces and
+				 * add them to the list.
 				 */
-				printf("Error in pcap_findalldevs_ex: %s", errbuf);
-			}
-			else
-			{
-				int i = 1;
-				for (d = alldevs; d; d = d->next)
-				{
-					const char* description = d->description ? d->description : "No description available";
-					if_q.addAnswer(i2s(i), d->name, string(d->name) + " (" + description + ")");
-					i++;
-				}
-			}
+				pcap_if_t* alldevs;
+				pcap_if_t* d;
+				char        errbuf[PCAP_ERRBUF_SIZE];
 
-			if (if_q.ask() != "")
-				os << "    adapter = \"" << if_q.getAnswer() << "\";\n";
+				if (pcap_findalldevs(&alldevs, errbuf) == -1)
+				{
+					/* No devices to add.
+					 */
+					printf("Error in pcap_findalldevs_ex: %s", errbuf);
+				}
+				else
+				{
+					int i = 1;
+					for (d = alldevs; d; d = d->next)
+					{
+						const char* description = d->description ? d->description : "No description available";
+						if_q.addAnswer(i2s(i), d->name, string(d->name) + " (" + description + ")");
+						i++;
+					}
+				}
+
+				if (if_q.ask() != "")
+					os << "    adapter = \"" << if_q.getAnswer() << "\";\n";
+#endif
+			}
 
 			FreeTextQuestion mac_q;
 			mac_q.setQuestion("What should the NIC's MAC address be?");

--- a/src/es40.cfg
+++ b/src/es40.cfg
@@ -443,11 +443,25 @@ sys0 = tsunami
 
   pci0.4 = dec21143 {
 
+    // VARIABLE: type
+    //
+    // Selects how this NIC talks to the host network:
+    //   "pcap" (the default) - capture/inject packets on an existing host
+    //          adapter via libpcap/npcap. Works on Windows and any Unix
+    //          with libpcap.
+    //   "tap"  - use a TAP virtual network device. Only available on
+    //          Linux, FreeBSD and NetBSD. Plays more nicely with host
+    //          firewalling/bridging than pcap's promiscuous capture.
+    //
+    //type = "pcap";
+    //type = "tap";
+
     // VARIABLE: adapter
     //
-    // Defines the host computer's adapter to use for the emulated NIC. If you're unsure
-    // of this, start the emulator without this variable set, and you will be presented
-    // with a list of adapters to choose from. You can enter the name indicated on this 
+    // type = "pcap": defines the host computer's adapter to use for the
+    // emulated NIC. If you're unsure of this, start the emulator without
+    // this variable set, and you will be presented with a list of
+    // adapters to choose from. You can enter the name indicated on this
     // line.
     //
     // Windows syntax:
@@ -457,6 +471,16 @@ sys0 = tsunami
     //adapter = "eth0"
     
     //adapter = "\Device\NPF_{F266CDC2-6BA2-43D8-8B00-1C468F737ED7}";
+
+    // type = "tap": the name of the TAP device to use. On Linux this is
+    // the TAP interface name, which can be created with
+    // `ip tuntap add mode tap <name>; ip link set dev <name> up` and
+    // possibly added to a bridge with `ip link set dev <name> master <bridge>`.
+    // On FreeBSD/NetBSD this references the TAP device node, eg. /dev/tap0,
+    // to be created eg. with `ifconfig tap0 create; ifconfig tap0 up` and
+    // add it with `brconfig bridge0 add tap0 up`.
+    //
+    //adapter = "tap0";
 
     // VARIABLE: mac
     //


### PR DESCRIPTION
Pull all libpcap code out of the Tulip emulator and place it into a "pcap" implementation. Also add a "tap" implementation that can work on Linux and *BSD.

  The initial patch was taken from https://github.com/lenticularis39/axpbox/pull/124
and, afaict, was created by Claude AI.

  This is tested to work on Linux with a bridge. Need to test is on some BSD,
and the pcap code is untested right now.