### PR TITLE
Zap unused variable

### DIFF
--- a/src/NetworkTap.cpp
+++ b/src/NetworkTap.cpp
@@ -123,7 +123,6 @@ bool CNetworkTap::init(const char *devid_string, CConfigurator *cfg)
 {
 	devid_for_log = devid_string;
 	char *adapter = cfg->get_text_value("adapter");
-	const char *tap_name = adapter ? adapter : "tap0";
 
 	if (!tap_open(devid_string, adapter))
 		return false;


### PR DESCRIPTION
[ 18%] Building CXX object CMakeFiles/es40.dir/src/NetworkTap.cpp.o /usr/lib/gcc-snapshot/bin/g++ -DES40_GIT_COMMIT=\"f4034401b527e8394475af5649f1655c52e27467\" -DHAVE_CONFIG_H -DHAVE_PCAP -DHAVE_SDL -DHAVE_TAP_NET -I/var/lib/jenkins/workspace/es40/es40/b1/src -I/var/lib/jenkins/workspace/es40/es40/src -I/var/lib/jenkins/workspace/es40/es40/src/emu -I/var/lib/jenkins/workspace/es40/es40/src/base -I/var/lib/jenkins/workspace/es40/es40/src/gui -g -Wall -Wextra -pedantic -std=gnu++17 -mavx2 -mfma -MD -MT CMakeFiles/es40.dir/src/NetworkTap.cpp.o -MF CMakeFiles/es40.dir/src/NetworkTap.cpp.o.d -o CMakeFiles/es40.dir/src/NetworkTap.cpp.o -c /var/lib/jenkins/workspace/es40/es40/src/NetworkTap.cpp /var/lib/jenkins/workspace/es40/es40/src/NetworkTap.cpp: In member function 'virtual bool CNetworkTap::init(const char*, CConfigurator*)': /var/lib/jenkins/workspace/es40/es40/src/NetworkTap.cpp:126:21: warning: unused variable 'tap_name' [-Wunused-variable]
  126 |         const char *tap_name = adapter ? adapter : "tap0";
      |                     ^~~~~~~~