### PR TITLE
Implement support for the macOS vmnet framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,16 @@ jobs:
             env "${configure_env[@]}" ./configure
           fi
 
+          # vmnet is a macOS-only backend; it must never be enabled on Linux.
+          if grep -q -- '-DHAVE_VMNET' src/Makefile; then
+            echo "Linux build was configured with vmnet support, which is macOS-only."
+            exit 1
+          fi
+          if grep -q -- '-framework vmnet' src/Makefile; then
+            echo "Linux build was configured to link the vmnet framework, which is macOS-only."
+            exit 1
+          fi
+
       - name: Build linux configuration validation target
         shell: bash
         run: |
@@ -396,6 +406,20 @@ jobs:
             Write-Host "Skipping Npcap provisioning for NN configuration: $configuration"
           }
 
+      - name: Verify vmnet is not enabled on Windows
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          # vmnet is a macOS-only backend: neither its source file nor its
+          # feature macro may appear in the Visual Studio projects.
+          $projects = Get-ChildItem -Path "src/Visual Studio" -Recurse -Include *.vcxproj, *.vcxproj.filters, *.props
+          $hits = $projects | Select-String -Pattern 'NetworkVmnet|HAVE_VMNET'
+          if ($hits) {
+            $hits | ForEach-Object { Write-Host $_.ToString() }
+            throw "Windows projects reference vmnet, which is macOS-only."
+          }
+
       - name: Build solution
         shell: pwsh
         run: |
@@ -600,6 +624,9 @@ jobs:
           if [[ "$is_no_network" -eq 1 ]]; then
             echo "Configuring without pcap for NN configuration: $configuration"
             configure_args+=(--disable-pcap)
+            # vmnet needs no external package, so it stays on unless asked to
+            # go away; NN builds must stay networkless.
+            configure_args+=(--disable-vmnet)
           fi
 
           if [[ "$is_no_screen" -eq 1 ]]; then
@@ -613,6 +640,23 @@ jobs:
             env "${configure_env[@]}" ./configure "${configure_args[@]}"
           else
             env "${configure_env[@]}" ./configure
+          fi
+
+          # vmnet is macOS-only, and is expected on every networked macOS build.
+          if [[ "$is_no_network" -eq 1 ]]; then
+            if grep -q -- '-DHAVE_VMNET' src/Makefile || grep -q -- '-framework vmnet' src/Makefile; then
+              echo "The NN configuration was configured with vmnet support: $configuration"
+              exit 1
+            fi
+          else
+            if ! grep -q -- '-DHAVE_VMNET' src/Makefile; then
+              echo "The macOS build was configured without vmnet support: $configuration"
+              exit 1
+            fi
+            if ! grep -q -- '-framework vmnet' src/Makefile; then
+              echo "The macOS build was configured without linking the vmnet framework: $configuration"
+              exit 1
+            fi
           fi
 
       - name: Build macOS configuration validation target (${{ matrix.configuration }})
@@ -752,6 +796,14 @@ jobs:
           fi
           if ! grep -q -- '-lpcap' src/Makefile; then
             echo "The macOS x86-64 JIT build was configured without linking libpcap."
+            exit 1
+          fi
+          if ! grep -q -- '-DHAVE_VMNET' src/Makefile; then
+            echo "The macOS x86-64 JIT build was configured without vmnet support."
+            exit 1
+          fi
+          if ! grep -q -- '-framework vmnet' src/Makefile; then
+            echo "The macOS x86-64 JIT build was configured without linking the vmnet framework."
             exit 1
           fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(ES40 VERSION 0.75.4 LANGUAGES C CXX)
 option(ES40_DISABLE_SDL "Disable SDL for headless builds" OFF)
 option(ES40_DISABLE_NETWORKING "Disable PCap/networking for networkless builds" OFF)
 option(ES40_DISABLE_TAP "Disable TAP networking even on platforms that support it (Linux/FreeBSD/NetBSD)" OFF)
+option(ES40_DISABLE_VMNET "Disable vmnet networking on macOS" OFF)
 option(ES40_DISABLE_LSS_LSM "Disable LSS/LSM (lockstep) builds." OFF)
 option(ES40_DISABLE_IDB "Disable IDB (built-in debugger) builds." OFF)
 option(ES40_DISABLE_ASMJIT "Disable ASMJIT" ON)
@@ -64,8 +65,12 @@ if (NOT ES40_DISABLE_NETWORKING)
             set(ES40_HAVE_TAP TRUE)
         endif()
 
-        if (NOT ES40_HAVE_PCAP AND NOT ES40_HAVE_TAP)
-            message(FATAL_ERROR "Networking was requested (ES40_DISABLE_NETWORKING=OFF) but neither libpcap nor TAP support is available for this platform/build. Install libpcap, or configure with -DES40_DISABLE_NETWORKING=ON to build without networking.")
+        if (NOT ES40_DISABLE_VMNET AND CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+            set(ES40_HAVE_VMNET TRUE)
+        endif()
+
+        if (NOT ES40_HAVE_PCAP AND NOT ES40_HAVE_TAP AND NOT ES40_HAVE_VMNET)
+            message(FATAL_ERROR "Networking was requested (ES40_DISABLE_NETWORKING=OFF) but neither libpcap nor TAP nor vmnet support is available for this platform/build. Install libpcap, or configure with -DES40_DISABLE_NETWORKING=ON to build without networking.")
         endif()
     endif()
 endif()
@@ -293,6 +298,7 @@ list(APPEND ES40_SOURCES
     src/NetworkBackend.cpp
     src/NetworkPcap.cpp
     src/NetworkTap.cpp
+    src/NetworkVmnet.cpp
     src/PCIDevice.cpp
     src/Port80.cpp
     src/S3Trio64.cpp
@@ -345,6 +351,10 @@ if (NOT ES40_DISABLE_NETWORKING)
     endif()
     if (ES40_HAVE_TAP)
         list(APPEND ES40_DEFINITIONS HAVE_TAP_NET)
+    endif()
+    if (ES40_HAVE_VMNET)
+        list(APPEND ES40_DEFINITIONS HAVE_VMNET)
+        list(APPEND ES40_LIBRARIES $<LINK_LIBRARY:FRAMEWORK,vmnet>)
     endif()
 endif()
 

--- a/configure.ac
+++ b/configure.ac
@@ -190,6 +190,12 @@ AC_ARG_ENABLE([tap],
   [],
   [enable_tap=yes])
 
+# Allow disabling vmnet support (macOS only) independently of pcap.
+AC_ARG_ENABLE([vmnet],
+  [AS_HELP_STRING([--disable-vmnet],[Disable vmnet networking (macOS only)])],
+  [],
+  [enable_vmnet=yes])
+
 have_pcap=no
 AS_IF([test "x$enable_pcap" != "xno"], [
   case "$host_os" in
@@ -232,6 +238,24 @@ AS_IF([test "x$enable_tap" != "xno"], [
       ;;
   esac
 ])
+
+# vmnet support: on macOS, the vmnet framework backend is
+# available even without libpcap.
+have_vmnet=no
+AS_IF([test "x$enable_vmnet" != "xno"], [
+  case "$host_os" in
+    darwin*)
+      AC_DEFINE([HAVE_VMNET],[1],[Use vmnet networking])
+      CXXFLAGS="$CXXFLAGS -DHAVE_VMNET"
+      LIBS="$LIBS -framework vmnet"
+      have_vmnet=yes
+      ;;
+    *)
+      ;;
+  esac
+])
+
+AM_CONDITIONAL([HAVE_VMNET], [test "x$have_vmnet" = "xyes"])
 
 AS_IF([test "x$enable_pcap" != "xno" -a "x$have_pcap" = "xno" \
        -a "x$have_tap" = "xno"], [

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-################################################################################
+ ################################################################################
 # ES40 emulator.
 # Copyright (C) 2007-2008 by the ES40 Emulator Project
 #
@@ -47,6 +47,11 @@
 
 bin_PROGRAMS = es40 es40_idb es40_lss es40_lsm es40_cfg
 
+# If we built with vmnet support, install the programs setuid to root
+if HAVE_VMNET
+INSTALL_PROGRAM += -m 4755
+endif
+
 AM_CPPFLAGS = -I$(top_srcdir)/src/emu
 
 #       Cirrus.cpp  - readd this to the sources line below when it's fixed
@@ -80,6 +85,7 @@ es40_SOURCES = AliM1543C.cpp \
        NetworkBackend.cpp \
        NetworkPcap.cpp \
        NetworkTap.cpp \
+       NetworkVmnet.cpp \
        PCIDevice.cpp \
        Port80.cpp \
        S3Trio64.cpp \

--- a/src/NetworkBackend.cpp
+++ b/src/NetworkBackend.cpp
@@ -21,7 +21,7 @@
 
 #include "StdAfx.h"
 
-#if defined(HAVE_PCAP) || defined(HAVE_TAP_NET)
+#if defined(HAVE_PCAP) || defined(HAVE_TAP_NET) || defined(HAVE_VMNET)
 
 #include "NetworkBackend.h"
 #include "Configurator.h"
@@ -33,6 +33,11 @@
 #if defined(HAVE_TAP_NET)
 #include "NetworkTap.h"
 #endif
+
+#if defined(HAVE_VMNET)
+#include "NetworkVmnet.h"
+#endif
+
 
 CNetworkBackend* create_network_backend(const char *devid_string,
                                         CConfigurator *cfg)
@@ -58,11 +63,20 @@ CNetworkBackend* create_network_backend(const char *devid_string,
 #endif
 	}
 
-	printf("%s: Unknown network backend type \"%s\"; expected \"pcap\" or "
-	       "\"tap\".\n", devid_string, type);
+	if (!strcasecmp(type, "vmnet")) {
+#if defined(HAVE_VMNET)
+		return new CNetworkVmnet();
+#else
+		printf("%s: \"vmnet\" support not compiled in.\n", devid_string);
+		return nullptr;
+#endif
+	}
+
+	printf("%s: Unknown network backend type \"%s\"; expected \"pcap\", "
+	       "\"tap\", or \"vmnet\".\n", devid_string, type);
 
 	return nullptr;
 
 }
 
-#endif /* defined(HAVE_PCAP) || defined(HAVE_TAP_NET)  */
+#endif /* defined(HAVE_PCAP) || defined(HAVE_TAP_NET) || defined(HAVE_VMNET) */

--- a/src/NetworkVmnet.cpp
+++ b/src/NetworkVmnet.cpp
@@ -1,0 +1,302 @@
+/* ES40 emulator.
+ *
+ * WWW    : https://github.com/ES40-Emu/es40
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Although this is not required, the author would appreciate being notified of,
+ * and receiving any modifications you may make to the source code that might serve
+ * the general public.
+ */
+
+#include "StdAfx.h"
+
+#if defined(HAVE_VMNET)
+
+#include "NetworkVmnet.h"
+#include "Configurator.h"
+
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <net/if_dl.h>
+#include <net/if_types.h>
+
+CNetworkVmnet::CNetworkVmnet():
+	vmnet_if(nullptr),
+	dispatch_q(nullptr),
+	dispatch_sem(nullptr),
+	rx_buf(nullptr),
+	devid_for_log(nullptr) { 
+}
+
+CNetworkVmnet::~CNetworkVmnet() { close(); }
+
+const char *strvmnetstatus (vmnet_return_t status) {
+	switch (status) {
+        case VMNET_SUCCESS:
+        	return "Successfully completed.";
+        case VMNET_FAILURE:
+        	return "General failure.";
+        case VMNET_MEM_FAILURE:
+        	return "Memory allocation failure.";
+        case VMNET_INVALID_ARGUMENT:
+        	return "Invalid argument specified.";
+        case VMNET_SETUP_INCOMPLETE:
+        	return "Interface setup is not complete.";
+        case VMNET_INVALID_ACCESS:
+        	return "Permission denied.";
+        case VMNET_PACKET_TOO_BIG:
+        	return "Packet size larger than MTU.";
+        case VMNET_BUFFER_EXHAUSTED:
+        	return "Buffers exhausted in kernel.";
+        case VMNET_TOO_MANY_PACKETS:
+        	return "Packet count exceeds limit.";
+        case VMNET_SHARING_SERVICE_BUSY:
+        	return "vmnet interface cannot be started as conflicting sharing service is in use.";
+        case VMNET_NOT_AUTHORIZED:
+        	return "The operation could not be completed due to missing authorization.";
+        otherwise:
+        	return "Unknown status code";
+        }
+}
+
+bool CNetworkVmnet::init(const char *devid_string, CConfigurator *cfg)
+{
+	__block bool success = false;
+	xpc_object_t interface_names = vmnet_copy_shared_interface_list ();
+        int n_interfaces, i;
+        struct ifaddrs *ifap, *ifa;
+	__block char *adapter = cfg->get_text_value ("adapter");
+	char *interface;
+
+	devid_for_log = devid_string;
+
+        if (interface_names == nullptr) {
+		printf ("%s: Cannot get list of vmnet capable interfaces.\n", devid_for_log);
+		return false;
+        } else
+		n_interfaces = xpc_array_get_count (interface_names);
+
+        if (getifaddrs (&ifap) < 0) {
+		printf ("%s: Unable to obtain network interface addresses.\n", devid_for_log);
+                xpc_release (interface_names);
+                return false;
+        }
+
+        if (adapter && adapter[0]) {
+		// Verify that vmnet can use this adapter
+		for (i = 0; i < n_interfaces; i++) {
+			interface = (char *) xpc_array_get_string (interface_names, i);
+                        if (strncmp (adapter, interface, IFNAMSIZ) == 0)
+                        	break;
+                }
+                if (n_interfaces == i) {
+                	printf ("%s: Adapter %s cannot serve as a bridge.\n", devid_for_log, adapter);
+                        freeifaddrs (ifap);
+                        xpc_release (interface_names);
+                        return false;
+                }
+                // Verify that the adapter has an Ethernet address
+                ifa = ifap;
+                while (ifa != NULL) {
+                	if (strncmp (adapter, ifa->ifa_name, IFNAMSIZ) == 0) {
+                        	if (ifa->ifa_addr != NULL && ifa->ifa_addr->sa_family == AF_INET)
+                                	break;
+                        }
+                }
+                ifa = ifa->ifa_next;
+                if (ifa == nullptr) {
+                	printf ("%s: Adapter %s does not have an Ethernet address.\n", devid_for_log, adapter);
+                        freeifaddrs (ifap);
+                        xpc_release (interface_names);
+                        return false;
+                }
+        }
+
+        else {
+        	// Use the first available interface with an Ethernet address
+		for (i = 0; i < n_interfaces; i++) {
+                	adapter = (char *) xpc_array_get_string (interface_names, i);
+                        ifa = ifap;
+                        while (ifa != NULL) {
+                        	if (strncmp (adapter, ifa->ifa_name, IFNAMSIZ) == 0) {
+                                	if (ifa->ifa_addr != NULL && ifa->ifa_addr->sa_family == AF_INET) {
+                                        	break;
+                                        }
+                                }
+                                ifa = ifa->ifa_next;
+                        }
+                        if (ifa != NULL)
+                        	break;
+                }
+                if (n_interfaces == i) {
+                        freeifaddrs (ifap);
+                        xpc_release (interface_names);
+                	printf ("%s: No network interfaces available to serve as a bridge.\n", devid_for_log);
+                        return false;
+                }
+                adapter = strndup (adapter, IFNAMSIZ);
+        }
+
+        freeifaddrs (ifap);
+        xpc_release (interface_names);
+
+	vmnet_interface_event_callback_t receive_handler = ^(interface_event_t event_mask, xpc_object_t event) {
+        	if (event_mask & VMNET_INTERFACE_PACKETS_AVAILABLE) {
+                  available_packets = xpc_dictionary_get_uint64 (event, vmnet_estimated_packets_available_key);
+                }
+        };
+
+	vmnet_start_interface_completion_handler_t finish_init = ^(vmnet_return_t status,
+                                                                   xpc_object_t __nullable interface_param) {
+        	if (status == VMNET_SUCCESS) {
+                	max_packet_size = xpc_dictionary_get_uint64 (interface_param, vmnet_max_packet_size_key);
+                        rx_buf = malloc (max_packet_size);
+                        status = vmnet_interface_set_event_callback (vmnet_if, VMNET_INTERFACE_PACKETS_AVAILABLE,
+                                                                     dispatch_q, receive_handler);
+                        if (status == VMNET_SUCCESS)
+                        	success = true;
+                        else
+                        	printf ("%s: Cannot setup %s to received packets: %s\n", devid_for_log, adapter,
+                                        strvmnetstatus (status));
+                } else
+                	printf ("%s: Unable to start vmnet on %s: %s\n", devid_for_log, adapter, strvmnetstatus (status));
+                dispatch_semaphore_signal (dispatch_sem);
+        };
+
+        dispatch_q = dispatch_queue_create (devid_string, DISPATCH_QUEUE_SERIAL);
+        dispatch_retain (dispatch_q);
+
+        dispatch_sem = dispatch_semaphore_create (0);
+        dispatch_retain (dispatch_sem);
+
+        xpc_object_t interface_desc = xpc_dictionary_create (NULL, NULL, 0);
+        xpc_dictionary_set_uint64 (interface_desc, vmnet_operation_mode_key, VMNET_BRIDGED_MODE);
+	xpc_dictionary_set_string (interface_desc, vmnet_shared_interface_name_key, adapter);
+	xpc_dictionary_set_bool (interface_desc, vmnet_allocate_mac_address_key, false);
+
+	vmnet_if = vmnet_start_interface (interface_desc, dispatch_q, finish_init);
+        dispatch_semaphore_wait (dispatch_sem, DISPATCH_TIME_FOREVER);
+
+        // Drop privileges if allowed
+	if (cfg->get_bool_value ("drop_privileges", true)) {
+        	seteuid (getuid ());
+                setegid (getgid ());
+        }
+
+	return success;
+}
+
+int CNetworkVmnet::send (const u8 *data, int len) {
+	struct iovec iovec;
+	struct vmpktdesc pktspec;
+	int pktCount = 1;
+	vmnet_return_t status;
+
+        if (vmnet_if == nullptr)
+        	return -1;
+
+	iovec.iov_base = (void*)data;
+	iovec.iov_len = len;
+	pktspec.vm_pkt_size = len;
+        pktspec.vm_pkt_iov = &iovec;
+        pktspec.vm_pkt_iovcnt = 1;
+        pktspec.vm_flags = 0;
+
+        status = vmnet_write (vmnet_if, &pktspec, &pktCount);
+        if (status != VMNET_SUCCESS) {
+		printf ("%s: Error sending packet: %s\n", devid_for_log, strvmnetstatus (status));
+		return -1;
+        }
+
+	return 0;
+}
+
+int CNetworkVmnet::receive (const u8 **data, int *len)
+{
+	struct iovec iovec;
+	struct vmpktdesc pktspec;
+	int pktCount = 1;
+	vmnet_return_t status;
+
+	if (vmnet_if == nullptr)
+		return -1;
+
+        if (available_packets == 0)
+		return 0;       // No packets available
+
+	iovec.iov_base = rx_buf;
+        iovec.iov_len = max_packet_size;
+        pktspec.vm_pkt_size = max_packet_size;
+        pktspec.vm_pkt_iov = &iovec;
+        pktspec.vm_pkt_iovcnt = 1;
+        pktspec.vm_flags = 0;
+
+	status = vmnet_read (vmnet_if, &pktspec, &pktCount);
+	available_packets--;
+
+	if (status == VMNET_SUCCESS) {
+                *data = (const u8*)rx_buf;
+		*len = (int)pktspec.vm_pkt_size;
+		return 1;
+	} else
+		printf ("%s: Error receiving packet: %s\n", devid_for_log, strvmnetstatus (status));
+
+	return -1;
+}
+
+void CNetworkVmnet::set_filter (u8 mac_list[][6], int num_macs,
+                                bool promiscuous, bool receive_all,
+                                bool pass_multicast, bool inverse)
+{
+	// The vmnet framework only delivers packets intended for this interface.
+	// The emulated NIC's own setup-frame handling still does perfect/hash
+	// filtering in software for anything delivered here.
+	(void) mac_list;
+	(void) num_macs;
+	(void) promiscuous;
+	(void) receive_all;
+	(void) pass_multicast;
+	(void) inverse;
+
+	return;
+}
+
+void CNetworkVmnet::close ()
+{
+  vmnet_interface_completion_handler_t finish_cleanup = ^(vmnet_return_t status) {
+    dispatch_release (dispatch_q);
+    dispatch_q = nullptr;
+    vmnet_if = nullptr;
+  };
+        if (vmnet_if != nullptr) {
+          vmnet_interface_set_event_callback (vmnet_if, 0, NULL, NULL);
+          vmnet_stop_interface (vmnet_if, dispatch_q, finish_cleanup);
+        }
+
+        if (dispatch_sem != nullptr) {
+          dispatch_release (dispatch_sem);
+          dispatch_q = nullptr;
+        }
+
+        if (rx_buf != nullptr) {
+          free (rx_buf);
+          rx_buf = nullptr;
+        }
+
+	return;
+}
+
+#endif /* defined(HAVE_VMNET)  */

--- a/src/NetworkVmnet.cpp
+++ b/src/NetworkVmnet.cpp
@@ -67,7 +67,7 @@ const char *strvmnetstatus (vmnet_return_t status) {
         	return "vmnet interface cannot be started as conflicting sharing service is in use.";
         case VMNET_NOT_AUTHORIZED:
         	return "The operation could not be completed due to missing authorization.";
-        otherwise:
+        default:
         	return "Unknown status code";
         }
 }

--- a/src/NetworkVmnet.h
+++ b/src/NetworkVmnet.h
@@ -1,0 +1,67 @@
+/* ES40 emulator.
+ *
+ * WWW    : https://github.com/ES40-Emu/es40
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Although this is not required, the author would appreciate being notified of,
+ * and receiving any modifications you may make to the source code that might serve
+ * the general public.
+ */
+
+/**
+ * \file
+ * vmnet network backend
+ *
+ * Host support:
+ *  - macOS: 
+ **/
+#ifndef INCLUDED_NETWORK_VMNET_H_
+#define INCLUDED_NETWORK_VMNET_H_
+
+#include "NetworkBackend.h"
+
+#if defined(HAVE_VMNET)
+
+#include <dispatch/dispatch.h>
+#include <xpc/xpc.h>
+#include <vmnet/vmnet.h>
+
+class CNetworkVmnet: public CNetworkBackend {
+public:
+	CNetworkVmnet();
+	virtual ~CNetworkVmnet();
+
+	virtual bool init(const char *devid_string, CConfigurator *cfg);
+	virtual int  send(const u8 *data, int len);
+	virtual int  receive(const u8 **data, int *len);
+	virtual void set_filter(u8 mac_list[][6], int num_macs,
+	                        bool promiscuous, bool receive_all,
+	                        bool pass_multicast, bool inverse);
+	virtual void close();
+
+private:
+	interface_ref        vmnet_if;
+	dispatch_queue_t     dispatch_q;
+	dispatch_semaphore_t dispatch_sem; 
+	uint64_t             max_packet_size;
+	uint64_t             available_packets;
+	void                *rx_buf;
+	const char          *devid_for_log;
+};
+
+#endif /* defined(HAVE_VMNET)  */
+
+#endif /* !defined(INCLUDED_NETWORK_VMNET_H_)  */

--- a/src/es40.cfg
+++ b/src/es40.cfg
@@ -458,16 +458,20 @@ sys0 = tsunami
     // VARIABLE: type
     //
     // Selects how this NIC talks to the host network:
-    //   "pcap" (the default) - capture/inject packets on an existing host
-    //          adapter via libpcap/npcap. Works on Windows and any Unix
-    //          with libpcap.
-    //   "tap"  - use a TAP virtual network device. Only available on
-    //          Linux, FreeBSD and NetBSD. Plays more nicely with host
-    //          firewalling/bridging than pcap's promiscuous capture.
+    //   "pcap"  (the default) - capture/inject packets on an existing host
+    //           adapter via libpcap/npcap. Works on Windows and any Unix
+    //           with libpcap.
+    //   "tap"   - use a TAP virtual network device. Only available on
+    //           Linux, FreeBSD and NetBSD. Plays more nicely with host
+    //           firewalling/bridging than pcap's promiscuous capture.
+    //   "vmnet" macOS only: Use the macOS vmnet framework which uses a
+    //           host's network interface as a bridge to effectively place
+    //           the Alpha system on the same subnet as the host.
     //
     //type = "pcap";
     //type = "tap";
-
+    //type = "vmnet";
+    
     // VARIABLE: adapter
     //
     // type = "pcap": defines the host computer's adapter to use for the
@@ -494,6 +498,10 @@ sys0 = tsunami
     //
     //adapter = "tap0";
 
+    // type = "vmnet": the name of the host's network interface to use as the bridge
+    //
+    //adapter = "en0";
+
     // VARIABLE: mac
     //
     // Defines the ethernet MAC address to be used by the virtual nic.
@@ -513,6 +521,17 @@ sys0 = tsunami
 
     //queue = 1024;
 
+    // VARIABLE: drop_privileges
+    //
+    // For vmnet interfaces, controls whether privileges are dropped after the
+    // interface is initialized. (ES40 starts with privileges enabled but
+    // doesn't need privileges once the network interfaces are initialized.)
+    // If you configure multiple network interfaces with vmnet, set this
+    // variable to false on all but the interface in the highest PCI slot.
+    // The default is true.
+    
+    // drop_privileges = true;
+    
     // VARIABLE: crc
     //
     // Calculate a real ethernet CRC (FCS) for frames delivered to the


### PR DESCRIPTION
The vmnet interface is implemented in the files `src/NetworkVmnet.h` and `src/NetworkVmnet.cpp`.

If you omit the `adapter` setting for a vmnet interface, it will automatically use the first available vmnet-capable host interface.

The vmnet framework works perfectly well with WiFi interfaces as well as Ethernet interfaces.

I have updated `src/es40.cfg` to describe the `vmnet` type and the new `drop_privileges` option for network interfaces. As ES40 is installed setuid to root when vmnet support is enabled, the vmnet code will drop privileges once the network interface is initialized. If you have multiple vmnet network interfaces, you should specify `drop_privileges: false;` in all but the interface in the highest PCI slot to ensure that privileges aren't dropped until after all interfaces are setup.

Configuration and Makefile changes:
  + `configure.ac` has been updated to add a `--disable-vmnet` option.
  + `CMakeFiles.txt` has been updated to add a `ES40_DISABLE_VMNET` option.
  + `src/Makefile.am` has been updated to install ES40 setuid to root when vmnet support is enabled.
